### PR TITLE
Enable processing of tree-less GraftM packages, fix premature taxonomy hash deletion

### DIFF
--- a/singlem/package_creator.py
+++ b/singlem/package_creator.py
@@ -33,51 +33,73 @@ class PackageCreator:
         logging.info("Detected package type as %s" %
                      ('protein' if is_protein_package else 'nucleotide'))
         if is_protein_package:
-            tree_leaves = set()
-            for node in dendropy.Tree.get(
-                    path=gpkg.reference_package_tree_path(),
-                    schema='newick').leaf_node_iter():
-                # need to replace here because otherwise they don't line up with the
-                # diamond database IDs
-                node_name = node.taxon.label.replace(' ','_')
-                if node_name in tree_leaves:
-                    raise Exception("Found duplicate tree leaf name in graftm package "
-                                    "tree. Currently this case is not handled, sorry")
-                tree_leaves.add(node_name)
-            for name in tree_leaves: #I don't think there is a 'peek' ?
-                eg_name = name
-                break
-            logging.info("Read in %i tree tip names e.g. %s" % (
-                len(tree_leaves), eg_name))
+            has_tree = True
+            # check if GraftM package contains tree file
+            try:
+                gpkg.reference_package_tree_path()
+            except KeyError:
+                has_tree = False
+                logging.info("Detected tree-less GraftM package.")
+            if has_tree:
+                tree_leaves = set()
+                for node in dendropy.Tree.get(
+                        path=gpkg.reference_package_tree_path(),
+                        schema='newick').leaf_node_iter():
+                    # need to replace here because otherwise they don't line up with the
+                    # diamond database IDs
+                    node_name = node.taxon.label.replace(' ','_')
+                    if node_name in tree_leaves:
+                        raise Exception("Found duplicate tree leaf name in graftm package "
+                                        "tree. Currently this case is not handled, sorry")
+                    tree_leaves.add(node_name)
+                for name in tree_leaves: #I don't think there is a 'peek' ?
+                    eg_name = name
+                    break
+                logging.info("Read in %i tree tip names e.g. %s" % (
+                    len(tree_leaves), eg_name))
 
-            # Make a new fasta file of all the sequences that are leaves
-            found_sequence_names = set()
-            num_seqs_unaligned = 0
-            filtered_aligned_tempfile = tempfile.NamedTemporaryFile(
-                prefix='singlem_package_creator',
-                suffix='.fasta',
-                mode='w')
-            for s in SeqIO.parse(gpkg.unaligned_sequence_database_path(), "fasta"):
-                num_seqs_unaligned += 1
-                if s.id in tree_leaves:
-                    if s.id in found_sequence_names:
-                        raise Exception("Found duplicate sequence names in graftm unaligned"
-                                        " sequence fasta file. Currently this case is not handled,"
-                                        " sorry")
+                # Make a new fasta file of all the sequences that are leaves
+                found_sequence_names = set()
+                num_seqs_unaligned = 0
+                filtered_aligned_tempfile = tempfile.NamedTemporaryFile(
+                    prefix='singlem_package_creator',
+                    suffix='.fasta',
+                    mode='w')
+                for s in SeqIO.parse(gpkg.unaligned_sequence_database_path(), "fasta"):
+                    num_seqs_unaligned += 1
+                    if s.id in tree_leaves:
+                        if s.id in found_sequence_names:
+                            raise Exception("Found duplicate sequence names in graftm unaligned"
+                                            " sequence fasta file. Currently this case is not handled,"
+                                            " sorry")
+                        SeqIO.write([s], filtered_aligned_tempfile, "fasta")
+                        found_sequence_names.add(s.id)
+                filtered_aligned_tempfile.flush()
+
+                if len(tree_leaves) != len(found_sequence_names):
+                    for t in tree_leaves:
+                        if t not in found_sequence_names:
+                            raise Exception("Found some sequences that were in the tree but not the"
+                                            " unaligned sequences database e.g. %s. Something is"
+                                            " likely amiss with the input GraftM package" % t)
+                    raise Exception("Programming error, shouldn't get here")
+                logging.info("All %i sequences found in tree extracted successfully from unaligned"
+                            " sequences fasta file, which originally had %i sequences" % (
+                                len(found_sequence_names), num_seqs_unaligned))
+            else:
+                # GraftM package has no tree
+                num_seqs_unaligned = 0
+                filtered_aligned_tempfile = tempfile.NamedTemporaryFile(
+                        prefix='singlem_package_creator',
+                        suffix='.fasta',
+                        mode='w')
+                for s in SeqIO.parse(gpkg.unaligned_sequence_database_path(), "fasta"):
+                    num_seqs_unaligned += 1
                     SeqIO.write([s], filtered_aligned_tempfile, "fasta")
-                    found_sequence_names.add(s.id)
-            filtered_aligned_tempfile.flush()
-
-            if len(tree_leaves) != len(found_sequence_names):
-                for t in tree_leaves:
-                    if t not in found_sequence_names:
-                        raise Exception("Found some sequences that were in the tree but not the"
-                                        " unaligned sequences database e.g. %s. Something is"
-                                        " likely amiss with the input GraftM package" % t)
-                raise Exception("Programming error, shouldn't get here")
-            logging.info("All %i sequences found in tree extracted successfully from unaligned"
-                         " sequences fasta file, which originally had %i sequences" % (
-                             len(found_sequence_names), num_seqs_unaligned))
+                filtered_aligned_tempfile.flush()
+                logging.info("All %i sequences found in tree extracted successfully from unaligned"
+                            " sequences fasta file, which originally had %i sequences" % (
+                                num_seqs_unaligned, num_seqs_unaligned))
 
             # Create a new diamond database
             dmnd_tf = tempfile.NamedTemporaryFile(prefix='singlem_package_creator',suffix='.dmnd')
@@ -92,12 +114,9 @@ class PackageCreator:
         tax_hash = {}
         with open(input_taxonomy) as tax:
             for line in tax:
-                    split_line = line.strip().split('\t')
-                    tax_hash[split_line[0]] = [taxa.strip() for taxa in split_line[1].split(';')]
-
+                split_line = line.strip().split('\t')
+                tax_hash[split_line[0]] = [taxa.strip() for taxa in split_line[1].split(';')]
         pickle.dump(tax_hash, taxonomy_hash_tf)
-        taxonomy_hash_tf.close()
-
 
         # Compile the final graftm/singlem package
         if len(gpkg.search_hmm_paths()) == 1 and \
@@ -128,6 +147,7 @@ class PackageCreator:
                                             taxonomy_hash_path)
 
             shutil.rmtree(gpkg_name)
+            taxonomy_hash_tf.close()
             if is_protein_package:
                 filtered_aligned_tempfile.close()
                 dmnd_tf.close()


### PR DESCRIPTION
Addresses #97 

Also fixes a bug where the taxonomy hash pickle is deleted before the final spkg is compiled.