### PR TITLE
Enable appraise to use default metapackage

### DIFF
--- a/bin/singlem
+++ b/bin/singlem
@@ -211,7 +211,7 @@ if __name__ == '__main__':
     appraise_otu_table_options.add_argument('--genome-archive-otu-tables', nargs='+', help="archive output of 'pipe' run on genomes")
     appraise_otu_table_options.add_argument('--assembly-otu-tables', nargs='+', help="output of 'pipe' run on assembled sequence")
     appraise_otu_table_options.add_argument('--assembly-archive-otu-tables', nargs='+', help="archive output of 'pipe' run on assembled sequence")
-    appraise_otu_table_options.add_argument('--metapackage', help='Metapackage used in the creation of the OTU tables', required=True)
+    appraise_otu_table_options.add_argument('--metapackage', help='Metapackage used in the creation of the OTU tables')
     appraise_inexact_options = appraise_parser.add_argument_group('Inexact appraisal options')
     appraise_inexact_options.add_argument('--imperfect', action='store_true', help="use sequence searching to account for genomes that are similar to those found in the metagenome [default: False]", default=False)
     appraise_inexact_options.add_argument('--sequence-identity', type=float, help="sequence identity cutoff to use if --imperfect is specified [default: ~genus level divergence i.e. %s]" % GENUS_LEVEL_AVERAGE_IDENTITY, default=GENUS_LEVEL_AVERAGE_IDENTITY)
@@ -820,7 +820,12 @@ if __name__ == '__main__':
                     metagenomes.add_archive_otu_table(f)
 
         logging.info("Removing hits that are not assigned to their target domains")
-        pkgs = Metapackage.acquire(args.metapackage).singlem_packages
+        if args.metapackage:
+            pkgs = Metapackage.acquire(args.metapackage).singlem_packages
+        else:
+            mpkg = Metapackage.acquire_default()
+            pkgs = mpkg.singlem_packages
+
         o2 = OtuTableCollection()
         o2.otu_table_objects.append(metagenomes.exclude_off_target_hits(pkgs))
         metagenomes = o2


### PR DESCRIPTION
Default metapackage seems to load ok, although get "Unknown search method naive" error. Presumably due to recent changes?

```
12/12/2022 01:42:35 PM INFO: Retrieval successful. Location of backpack is: /home/aroneys/s/aroneys/db/SingleM/S3.0.5.metapackage20220806.smpkg.zb
12/12/2022 01:42:35 PM INFO: Loaded 59 SingleM packages
12/12/2022 01:42:36 PM INFO: Read in 3377 markers from the different genomes
...
12/12/2022 01:42:37 PM INFO: Finished singlem DB creation
Traceback (most recent call last):
  File "/home/aroneys/m/users/aroneys/.conda/envs/singlem-dev/bin/singlem", line 7, in <module>
    exec(compile(f.read(), __file__, 'exec'))
  File "/mnt/hpccs01/scratch/microbiome/aroneys/src/singlem/bin/singlem", line 867, in <module>
    app = appraiser.appraise(genome_otu_table_collection=genomes,
  File "/mnt/hpccs01/scratch/microbiome/aroneys/src/singlem/bin/../singlem/appraiser.py", line 56, in appraise
    sample_to_binned = self._appraise_inexactly(
  File "/mnt/hpccs01/scratch/microbiome/aroneys/src/singlem/bin/../singlem/appraiser.py", line 140, in _appraise_inexactly
    queries = querier.query_with_queries(metagenome_collection, sdb_tmp, max_divergence, 'naive', SequenceDatabase.NUCLEOTIDE_TYPE, 1, None, True, None)
  File "/mnt/hpccs01/scratch/microbiome/aroneys/src/singlem/bin/../singlem/querier.py", line 167, in query_with_queries
    raise Exception("Unknown search method {}".format(search_method))
Exception: Unknown search method naive
```