### PR TITLE
query: Default to False for --continue-on-missing-genes.

### DIFF
--- a/bin/singlem
+++ b/bin/singlem
@@ -299,7 +299,7 @@ if __name__ == '__main__':
     query_other_args.add_argument('--taxonomy', metavar='name', help='Print all OTUs assigned a taxonomy including this string e.g. \'Archaea\'')
     query_other_args.add_argument('--dump', action='store_true', help='Print all OTUs in the DB')
     # continue_on_missing_genes
-    query_other_args.add_argument('--continue-on-missing-genes', action='store_true', help='Continue if a gene is missing from the DB. Only works with smafa/nuclotide search method.')
+    query_other_args.add_argument('--continue-on-missing-genes', action='store_true', help='Continue if a gene is missing from the DB. Only works with smafa/nuclotide search method.', default=False)
     current_default = None
 
     summarise_description = 'Summarise and transform taxonomic profiles and OTU tables.'

--- a/singlem/querier.py
+++ b/singlem/querier.py
@@ -168,7 +168,7 @@ class Querier:
         logging.info("Sorted {} OTU queries ..".format(total_otu_count))
         return MarkerSortedQueryInput(sorted_io)
 
-    def query_with_queries(self, queries, sdb, max_divergence, search_method, sequence_type, max_nearest_neighbours, max_search_nearest_neighbours, preload_db, limit_per_sequence, continue_on_missing_genes):
+    def query_with_queries(self, queries, sdb, max_divergence, search_method, sequence_type, max_nearest_neighbours, max_search_nearest_neighbours, preload_db, limit_per_sequence, continue_on_missing_genes=False):
         if max_divergence == 0 and sequence_type == SequenceDatabase.NUCLEOTIDE_TYPE:
             if limit_per_sequence != None:
                 raise Exception("limit-per-sequence has not been implemented for nucleotide queries with max-divergence 0 yet")


### PR DESCRIPTION
Fix for 5dafeb329c11413520305ad5de42a8d307327a3c.