### PR TITLE
Implement independent appraise cutoffs

### DIFF
--- a/bin/singlem
+++ b/bin/singlem
@@ -221,7 +221,9 @@ if __name__ == '__main__':
     appraise_otu_table_options.add_argument('--metapackage', help='Metapackage used in the creation of the OTU tables')
     appraise_inexact_options = appraise_parser.add_argument_group('Inexact appraisal options')
     appraise_inexact_options.add_argument('--imperfect', action='store_true', help="use sequence searching to account for genomes that are similar to those found in the metagenome [default: False]", default=False)
-    appraise_inexact_options.add_argument('--sequence-identity', type=float, help="sequence identity cutoff to use if --imperfect is specified [default: ~species level divergence i.e. %s]" % SPECIES_LEVEL_AVERAGE_IDENTITY, default=SPECIES_LEVEL_AVERAGE_IDENTITY)
+    appraise_inexact_options.add_argument('--taxa-level-cutoff', help="Appraise at specified taxa level [default: species]", default="genus")
+    appraise_inexact_options.add_argument('--taxa-level-json', help="Json file containing Appraise cutoffs at each taxa level")
+    appraise_inexact_options.add_argument('--sequence-identity', type=float, help="sequence identity cutoff to use if --imperfect is specified [default: unset]", default=None)
     appraise_plot_group = appraise_parser.add_argument_group("Plotting-related options")
     appraise_plot_group.add_argument('--plot', help='Output plot SVG filename (marker chosen automatically unless --plot-marker is also specified)', default=None)
     appraise_plot_group.add_argument('--plot-marker', help='Marker gene to plot OTUs from', default=None)
@@ -913,8 +915,9 @@ if __name__ == '__main__':
                                 force = args.force)
     elif args.subparser_name == 'appraise':
         from singlem.otu_table_collection import OtuTableCollection
-        from singlem.appraiser import Appraiser
+        from singlem.appraiser import Appraiser, AppraiseMaxDivergenceCutoffs
         from singlem.metapackage import Metapackage
+        import polars as pl
 
         if not args.metagenome_otu_tables and not args.metagenome_archive_otu_tables:
             raise Exception("Appraise requires metagenome OTU tables or archive tables")
@@ -923,6 +926,18 @@ if __name__ == '__main__':
             raise Exception("Appraise archive output format requires metagenome archive input")
 
         appraiser = Appraiser()
+
+        if args.imperfect and not args.sequence_identity:
+            if not args.taxa_level_cutoff:
+                raise Exception("Appraise imperfect requires either taxa-level-cutoff or sequence-identity input")
+
+            taxa_level_cutoffs = AppraiseMaxDivergenceCutoffs.from_polars(
+                pl.read_json(args.taxa_level_json),
+                taxa_level = args.taxa_level_cutoff,
+                window_size = DEFAULT_WINDOW_SIZE
+                )
+        else:
+            taxa_level_cutoffs = None
 
         metagenomes = OtuTableCollection()
         if args.metagenome_otu_tables:
@@ -993,6 +1008,7 @@ if __name__ == '__main__':
                                 assembly_otu_table_collection=assemblies,
                                 output_found_in = args.output_found_in,
                                 imperfect = args.imperfect,
+                                taxa_level_cutoffs = taxa_level_cutoffs,
                                 sequence_identity=(args.sequence_identity if args.imperfect else None),
                                 packages=pkgs,
                                 window_size=DEFAULT_WINDOW_SIZE)

--- a/bin/singlem
+++ b/bin/singlem
@@ -992,6 +992,7 @@ if __name__ == '__main__':
                                 metagenome_otu_table_collection=metagenomes,
                                 assembly_otu_table_collection=assemblies,
                                 output_found_in = args.output_found_in,
+                                imperfect = args.imperfect,
                                 sequence_identity=(args.sequence_identity if args.imperfect else None),
                                 packages=pkgs,
                                 window_size=DEFAULT_WINDOW_SIZE)

--- a/extras/process_interlineage_distances.py
+++ b/extras/process_interlineage_distances.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+
+"""
+Author: Samuel Aroney
+Process output from inter_lineage_distance_calculator.py
+"""
+
+import sys
+import argparse
+import logging
+import polars as pl
+
+def main(arguments):
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument('--debug', help='output debug information', action="store_true")
+    parser.add_argument('--quiet', help='only output errors', action="store_true")
+
+    parser.add_argument("--interlineage-distances", help="File containing interlineage distances", required=True)
+    parser.add_argument("--output", help="Output json file with package-domain cutoffs", required=True)
+
+    args = parser.parse_args(arguments)
+
+    # Setup logging
+    if args.debug:
+        loglevel = logging.DEBUG
+    elif args.quiet:
+        loglevel = logging.ERROR
+    else:
+        loglevel = logging.INFO
+    logging.basicConfig(level=loglevel, format='%(asctime)s %(levelname)s: %(message)s', datefmt='%Y/%m/%d %I:%M:%S %p')
+
+    trim = 0.1
+    trimmed = (pl.col("distance") >= pl.col("distance").quantile(trim)) | (pl.col("distance") <= pl.col("distance").quantile(1 - trim))
+    distances = (
+        pl.read_csv(args.interlineage_distances, separator="\t")
+        .groupby("rank", "singlem_package", "domain", "taxon")
+        .agg(distance = pl.col("distance").filter(trimmed).mean())
+        .groupby("rank", "singlem_package", "domain")
+        .agg(distance = pl.col("distance").filter(trimmed).mean())
+        .pivot(values = "distance", columns = "rank", index = ["singlem_package", "domain"], aggregate_function=None)
+        .select(
+            "singlem_package", "domain",
+            phylum_cutoff = pl.sum_horizontal("d", "p") / 2,
+            class_cutoff = pl.sum_horizontal("p", "c") / 2,
+            order_cutoff = pl.sum_horizontal("c", "o") / 2,
+            family_cutoff = pl.sum_horizontal("o", "f") / 2,
+            genus_cutoff = pl.sum_horizontal("f", "g") / 2,
+        )
+        .sort("singlem_package", "domain")
+    )
+    distances.write_json(args.output, pretty=True)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/singlem/appraiser.py
+++ b/singlem/appraiser.py
@@ -35,6 +35,7 @@ class Appraiser:
         metagenome_otu_table_collection = kwargs.pop('metagenome_otu_table_collection')
         assembly_otu_table_collection = kwargs.pop('assembly_otu_table_collection', None)
         packages = kwargs.pop('packages')
+        imperfect = kwargs.pop('imperfect', False)
         sequence_identity = kwargs.pop('sequence_identity', None)
         output_found_in = kwargs.pop('output_found_in', False)
         window_size = kwargs.pop('window_size')
@@ -61,6 +62,7 @@ class Appraiser:
             sample_to_binned = self._appraise_inexactly(
                 metagenome_otu_table_collection,
                 filtered_genome_otus,
+                imperfect,
                 sequence_identity,
                 output_found_in,
                 packages,
@@ -70,6 +72,7 @@ class Appraiser:
             sample_to_assembled = self._appraise_inexactly(
                 metagenome_otu_table_collection,
                 assembly_otu_table_collection,
+                imperfect,
                 sequence_identity,
                 output_found_in,
                 packages,
@@ -111,6 +114,7 @@ class Appraiser:
 
     def _appraise_inexactly(self, metagenome_otu_table_collection,
                             found_otu_collection,
+                            imperfect,
                             sequence_identity,
                             output_found_in,
                             packages,

--- a/singlem/appraiser.py
+++ b/singlem/appraiser.py
@@ -418,3 +418,20 @@ class AppraiseMaxDivergenceCutoffs:
 
     def get_maxdivergence(self, gene, domain):
         return self.cutoffs[gene][domain]
+
+    @classmethod
+    def from_polars(cls, df, taxa_level, window_size):
+        df = (
+            df
+            .select("singlem_package", "domain", cutoff = taxa_level + "_cutoff")
+            .iter_rows()
+        )
+
+        cutoffs = {}
+        for row in df:
+            if row[0] not in cutoffs:
+                cutoffs[row[0]] = {}
+
+            cutoffs[row[0]][row[1]] = row[2]
+
+        return cls(cutoffs, window_size)

--- a/singlem/appraiser.py
+++ b/singlem/appraiser.py
@@ -405,8 +405,16 @@ class AppraisalBuildingBlock:
         return out
 
 class AppraiseMaxDivergenceCutoffs:
-    def __init__(self, cutoffs):
-        self.cutoffs = cutoffs
+    def __init__(self, cutoffs, window_size):
+        self.cutoffs = {
+            gene: {
+                domain:
+                    # max divergence must be a whole number, and we round down
+                    int(window_size * (1 - cutoffs[gene][domain]))
+                for domain in cutoffs[gene].keys()
+                }
+            for gene in cutoffs.keys()
+            }
 
     def get_maxdivergence(self, gene, domain):
         return self.cutoffs[gene][domain]

--- a/singlem/otu_table_entry.py
+++ b/singlem/otu_table_entry.py
@@ -34,6 +34,12 @@ class OtuTableEntry:
             except IndexError:
                 self.data.append(found_in)
 
+    def get_domain(self):
+        try:
+            return self.taxonomy_array()[1]
+        except IndexError:
+            return None
+
     def __str__(self):
         return "\t".join([self.marker, self.sample_name, self.sequence,
                           str(self.count), str(self.coverage), self.taxonomy])

--- a/test/data/appraise_example4/bins.otu_table.tsv
+++ b/test/data/appraise_example4/bins.otu_table.tsv
@@ -1,0 +1,9 @@
+gene	sample	sequence	num_hits	coverage	taxonomy
+4.11.ribosomal_protein_L10	genome_1	GGTAAAGCGAATCCAGCACCACCAGTTGGTCCAGCATTAGGTCAAGCAGGTGTGAACATT	1	1.02	Root; d__Bacteria; p__Firmicutes; c__Bacilli
+4.11.ribosomal_protein_L10	genome_2	TGCGGCGGCGCCAACGGCGAGGCCGGAGCGGTCCGCCTCGGCATCGCCCGCGCGCTCGTT	1	1.02	Root; d__Archaea; p__Crenarchaeota; c__Thermoprotei
+4.12.ribosomal_protein_L11_rplK	genome_1	CCGGGAGGGAAAGTGAACCCCGCTCCTCCAATCGGGCCGGCGCTCGGCCAGCACGGCGTT	1	1.02	Root; d__Bacteria; p__Firmicutes; c__Bacilli
+4.12.ribosomal_protein_L11_rplK	genome_2	ATTCCACTGCCGACCAAGAAGAGTACATTCACGGTTGTAAAAAGCCCGCATGTCTATAAT	1	1.02	Root; d__Archaea; p__Crenarchaeota; c__Thermoprotei
+4.14.ribosomal_protein_L16_L10E_rplP	genome_1	ACGATCTTCCCGGACCGTCCGGTCACGAAGAAGCCGGCCGAGACCCGTCAGGGTTCGGGT	1	1.02	Root; d__Bacteria; p__Firmicutes; c__Bacilli
+4.14.ribosomal_protein_L16_L10E_rplP	genome_2	AGAGTATATCCACACATTTTGTTAAGAGAGAACAAGATGATTGCAACAGCAGGTGCAGAT	1	1.02	Root; d__Archaea; p__Crenarchaeota; c__Thermoprotei
+4.16.ribosomal_protein_S5	genome_1	GGTACCGGCGTGATCGCGGGTGGGGGCGTCCGCGCCGTGCTCGAGCTGGCCGGGATTCGT	1	1.02	Root; d__Bacteria; p__Firmicutes; c__Bacilli
+4.16.ribosomal_protein_S5	genome_2	GGATTAGGTCTTGTAGCAGGAGAAAACATAAAAAATCTATTAAAGCTTGCTGGTATTAAT	1	1.02	Root; d__Archaea; p__Crenarchaeota; c__Thermoprotei

--- a/test/data/appraise_example4/package_domain_cutoffs.json
+++ b/test/data/appraise_example4/package_domain_cutoffs.json
@@ -1,0 +1,102 @@
+{
+  "columns": [
+    {
+      "name": "singlem_package",
+      "datatype": "Utf8",
+      "values": [
+        "4.11.ribosomal_protein_L10",
+        "4.11.ribosomal_protein_L10",
+        "4.12.ribosomal_protein_L11_rplK",
+        "4.12.ribosomal_protein_L11_rplK",
+        "4.14.ribosomal_protein_L16_L10E_rplP",
+        "4.14.ribosomal_protein_L16_L10E_rplP",
+        "4.16.ribosomal_protein_S5",
+        "4.16.ribosomal_protein_S5"
+      ]
+    },
+    {
+      "name": "domain",
+      "datatype": "Utf8",
+      "values": [
+        "d__Archaea",
+        "d__Bacteria",
+        "d__Archaea",
+        "d__Bacteria",
+        "d__Archaea",
+        "d__Bacteria",
+        "d__Archaea",
+        "d__Bacteria"
+      ]
+    },
+    {
+      "name": "phylum_cutoff",
+      "datatype": "Float64",
+      "values": [
+        0.65,
+        0.69,
+        0.67,
+        0.75,
+        0.63,
+        0.68,
+        0.56,
+        0.69
+      ]
+    },
+    {
+      "name": "class_cutoff",
+      "datatype": "Float64",
+      "values": [
+        0.68,
+        0.71,
+        0.70,
+        0.79,
+        0.66,
+        0.70,
+        0.60,
+        0.72
+      ]
+    },
+    {
+      "name": "order_cutoff",
+      "datatype": "Float64",
+      "values": [
+        0.68,
+        0.74,
+        0.69,
+        0.81,
+        0.70,
+        0.74,
+        0.62,
+        0.75
+      ]
+    },
+    {
+      "name": "family_cutoff",
+      "datatype": "Float64",
+      "values": [
+        0.72,
+        0.79,
+        0.74,
+        0.85,
+        0.75,
+        0.79,
+        0.68,
+        0.80
+      ]
+    },
+    {
+      "name": "genus_cutoff",
+      "datatype": "Float64",
+      "values": [
+        0.89,
+        0.86,
+        0.89,
+        0.86,
+        0.93,
+        0.96,
+        0.93,
+        0.96
+      ]
+    }
+  ]
+}

--- a/test/data/appraise_example4/reads.otu_table.tsv
+++ b/test/data/appraise_example4/reads.otu_table.tsv
@@ -1,0 +1,17 @@
+gene	sample	sequence	num_hits	coverage	taxonomy
+4.11.ribosomal_protein_L10	minimal	TGCGGCGGCGCCAACGGCGAGGCCGGAGCGGTCCGCCTCGGCATCGCCCGCGCGCTCGTG	7	17.07	Root; d__Archaea; p__Crenarchaeota; c__Thermoprotei; o__Sulfolobales; f__Sulfolobaceae
+4.11.ribosomal_protein_L10	minimal	TGCGGCGGCGCCAACGGCGAGGCCGGAGCGGTCCGCCTCGGCATCGCCCGAAAAAAAAAA	4	9.76	Root; d__Archaea; p__Crenarchaeota; c__Thermoprotei; o__Sulfolobales; f__Sulfolobaceae; g__Metallosphaera; s__Metallosphaera_yellowstonensis
+4.12.ribosomal_protein_L11_rplK	minimal	ATTCCACTGCCGACCAAGAAGAGTACATTCACGGTTGTAAAAAGCCCGCATGTCTATAAA	7	17.07	Root; d__Archaea; p__Crenarchaeota; c__Thermoprotei; o__Sulfolobales; f__Sulfolobaceae
+4.12.ribosomal_protein_L11_rplK	minimal	ATTCCACTGCCGACCAAGAAGAGTACATTCACGGTTGTAAAAAGCCCGCATGTAAGAGGG	4	9.76	Root; d__Archaea; p__Crenarchaeota; c__Thermoprotei; o__Sulfolobales; f__Sulfolobaceae; g__Metallosphaera; s__Metallosphaera_yellowstonensis
+4.14.ribosomal_protein_L16_L10E_rplP	minimal	AGAGTATATCCACACATTTTGTTAAGAGAGAACAAGATGATTGCAACAGCAGGTGCAGAC	7	17.07	Root; d__Archaea; p__Crenarchaeota; c__Thermoprotei; o__Sulfolobales; f__Sulfolobaceae
+4.14.ribosomal_protein_L16_L10E_rplP	minimal	AGAGTATATCCACACATTTTGTTAAGAGAGAACAAGATGATTGCAACAGCGAAAAAGAGA	4	9.76	Root; d__Archaea; p__Crenarchaeota; c__Thermoprotei; o__Sulfolobales; f__Sulfolobaceae; g__Metallosphaera; s__Metallosphaera_yellowstonensis
+4.16.ribosomal_protein_S5	minimal	GGATTAGGTCTTGTAGCAGGAGAAAACATAAAAAATCTATTAAAGCTTGCTGGTATTAAG	7	17.07	Root; d__Archaea; p__Crenarchaeota; c__Thermoprotei; o__Sulfolobales; f__Sulfolobaceae
+4.16.ribosomal_protein_S5	minimal	GGATTAGGTCTTGTAGCAGGAGAAAACATAAAAAATCTATTAAAGCTTGCTGGTATTGGA	4	9.76	Root; d__Archaea; p__Crenarchaeota; c__Thermoprotei; o__Sulfolobales; f__Sulfolobaceae; g__Metallosphaera; s__Metallosphaera_yellowstonensis
+4.11.ribosomal_protein_L10	minimal	GGTAAAGCGAATCCAGCACCACCAGTTGGTCCAGCATTAGGTCAAGCAGGTGTGAACATC	7	17.07	Root; d__Bacteria; p__Firmicutes; c__Bacilli; o__Bacillales
+4.11.ribosomal_protein_L10	minimal	GGTAAAGCGAATCCAGCACCACCAGTTGGTCCAGCATTAGGTCAAGCAGGAAAAGGAGAA	4	9.76	Root; d__Bacteria; p__Firmicutes; c__Bacilli; o__Bacillales; f__Staphylococcaceae; g__Staphylococcus
+4.12.ribosomal_protein_L11_rplK	minimal	CCGGGAGGGAAAGTGAACCCCGCTCCTCCAATCGGGCCGGCGCTCGGCCAGCACGGCGTC	7	17.07	Root; d__Bacteria; p__Firmicutes; c__Bacilli; o__Bacillales
+4.12.ribosomal_protein_L11_rplK	minimal	CCGGGAGGGAAAGTGAACCCCGCTCCTCCAATCGGGCCGGCGCTCGGCCAGCAAAAAAAA	4	9.76	Root; d__Bacteria; p__Firmicutes; c__Bacilli; o__Bacillales; f__Staphylococcaceae; g__Staphylococcus
+4.14.ribosomal_protein_L16_L10E_rplP	minimal	ACGATCTTCCCGGACCGTCCGGTCACGAAGAAGCCGGCCGAGACCCGTCAGGGTTCGGGG	7	17.07	Root; d__Bacteria; p__Firmicutes; c__Bacilli; o__Bacillales
+4.14.ribosomal_protein_L16_L10E_rplP	minimal	ACGATCTTCCCGGACCGTCCGGTCACGAAGAAGCCGGCCGAGACCCGTCAAAAAAAAAAA	4	9.76	Root; d__Bacteria; p__Firmicutes; c__Bacilli; o__Bacillales; f__Staphylococcaceae; g__Staphylococcus
+4.16.ribosomal_protein_S5	minimal	GGTACCGGCGTGATCGCGGGTGGGGGCGTCCGCGCCGTGCTCGAGCTGGCCGGGATTCGC	7	17.07	Root; d__Bacteria; p__Firmicutes; c__Bacilli; o__Bacillales
+4.16.ribosomal_protein_S5	minimal	GGTACCGGCGTGATCGCGGGTGGGGGCGTCCGCGCCGTGCTCGAGCTGGCCGGGATTAAA	4	9.76	Root; d__Bacteria; p__Firmicutes; c__Bacilli; o__Bacillales; f__Staphylococcaceae; g__Staphylococcus

--- a/test/test_appraise.py
+++ b/test/test_appraise.py
@@ -488,6 +488,74 @@ class Tests(unittest.TestCase):
         self.assertEqual({'d__Archaea': round(sum([4, 4, 4, 0]) / 4), 'd__Bacteria': round(sum([4, 0, 4, 4]) / 4)}, a.num_not_found)
 
 
+    def test_clusterer_taxa_level_cli(self):
+        with in_tempdir():
+            cmd = (
+                f"{path_to_script} appraise "
+                f"--metagenome-otu-tables {path_to_data}/appraise_example4/reads.otu_table.tsv "
+                f"--genome-otu-tables {path_to_data}/appraise_example4/bins.otu_table.tsv "
+                f"--metapackage {path_to_data}/four_package.smpkg "
+                f"--imperfect "
+                f"--taxa-level-cutoff genus "
+                f"--taxa-level-json {path_to_data}/appraise_example4/package_domain_cutoffs.json "
+                f"--output-binned-otu-table binned.otu_table.tsv "
+                f"--output-unaccounted-for-otu-table unbinned.otu_table.tsv "
+            )
+            extern.run(cmd)
+
+            expected_binned = [
+                self.headers,
+                # one bp different from genome - binned
+                ['4.11.ribosomal_protein_L10','minimal','GGTAAAGCGAATCCAGCACCACCAGTTGGTCCAGCATTAGGTCAAGCAGGTGTGAACATC','7','17.07','Root; d__Bacteria; p__Firmicutes; c__Bacilli; o__Bacillales'],
+                # one bp different from genome - binned
+                ['4.12.ribosomal_protein_L11_rplK','minimal','CCGGGAGGGAAAGTGAACCCCGCTCCTCCAATCGGGCCGGCGCTCGGCCAGCACGGCGTC','7','17.07','Root; d__Bacteria; p__Firmicutes; c__Bacilli; o__Bacillales'],
+                # 7 bp different from genome - binned
+                ['4.12.ribosomal_protein_L11_rplK','minimal','CCGGGAGGGAAAGTGAACCCCGCTCCTCCAATCGGGCCGGCGCTCGGCCAGCAAAAAAAA','4','9.76','Root; d__Bacteria; p__Firmicutes; c__Bacilli; o__Bacillales; f__Staphylococcaceae; g__Staphylococcus'],
+                # one bp different from genome - binned
+                ['4.14.ribosomal_protein_L16_L10E_rplP','minimal','ACGATCTTCCCGGACCGTCCGGTCACGAAGAAGCCGGCCGAGACCCGTCAGGGTTCGGGG','7','17.07','Root; d__Bacteria; p__Firmicutes; c__Bacilli; o__Bacillales'],
+                # one bp different from genome - binned
+                ['4.16.ribosomal_protein_S5','minimal','GGTACCGGCGTGATCGCGGGTGGGGGCGTCCGCGCCGTGCTCGAGCTGGCCGGGATTCGC','7','17.07','Root; d__Bacteria; p__Firmicutes; c__Bacilli; o__Bacillales'],
+                # one bp different from genome - binned
+                ['4.11.ribosomal_protein_L10','minimal','TGCGGCGGCGCCAACGGCGAGGCCGGAGCGGTCCGCCTCGGCATCGCCCGCGCGCTCGTG','7','17.07','Root; d__Archaea; p__Crenarchaeota; c__Thermoprotei; o__Sulfolobales; f__Sulfolobaceae'],
+                # one bp different from genome - binned
+                ['4.12.ribosomal_protein_L11_rplK','minimal','ATTCCACTGCCGACCAAGAAGAGTACATTCACGGTTGTAAAAAGCCCGCATGTCTATAAA','7','17.07','Root; d__Archaea; p__Crenarchaeota; c__Thermoprotei; o__Sulfolobales; f__Sulfolobaceae'],
+                # one bp different from genome - binned
+                ['4.14.ribosomal_protein_L16_L10E_rplP','minimal','AGAGTATATCCACACATTTTGTTAAGAGAGAACAAGATGATTGCAACAGCAGGTGCAGAC','7','17.07','Root; d__Archaea; p__Crenarchaeota; c__Thermoprotei; o__Sulfolobales; f__Sulfolobaceae'],
+                # one bp different from genome - binned
+                ['4.16.ribosomal_protein_S5','minimal','GGATTAGGTCTTGTAGCAGGAGAAAACATAAAAAATCTATTAAAGCTTGCTGGTATTAAG','7','17.07','Root; d__Archaea; p__Crenarchaeota; c__Thermoprotei; o__Sulfolobales; f__Sulfolobaceae'],
+                # 3 bp different from genome - binned
+                ['4.16.ribosomal_protein_S5','minimal','GGATTAGGTCTTGTAGCAGGAGAAAACATAAAAAATCTATTAAAGCTTGCTGGTATTGGA','4','9.76','Root; d__Archaea; p__Crenarchaeota; c__Thermoprotei; o__Sulfolobales; f__Sulfolobaceae; g__Metallosphaera; s__Metallosphaera_yellowstonensis'],
+                ""
+            ]
+            expected_binned = "\n".join(["\t".join(x) for x in expected_binned])
+
+            expected_unbinned = [
+                self.headers,
+                # 10 bp different from genome - unbinned
+                ['4.11.ribosomal_protein_L10','minimal','TGCGGCGGCGCCAACGGCGAGGCCGGAGCGGTCCGCCTCGGCATCGCCCGAAAAAAAAAA','4','9.76','Root; d__Archaea; p__Crenarchaeota; c__Thermoprotei; o__Sulfolobales; f__Sulfolobaceae; g__Metallosphaera; s__Metallosphaera_yellowstonensis'],
+                # 7 bp different from genome - unbinned
+                ['4.12.ribosomal_protein_L11_rplK','minimal','ATTCCACTGCCGACCAAGAAGAGTACATTCACGGTTGTAAAAAGCCCGCATGTAAGAGGG','4','9.76','Root; d__Archaea; p__Crenarchaeota; c__Thermoprotei; o__Sulfolobales; f__Sulfolobaceae; g__Metallosphaera; s__Metallosphaera_yellowstonensis'],
+                # 10 bp different from genome - unbinned
+                ['4.14.ribosomal_protein_L16_L10E_rplP','minimal','AGAGTATATCCACACATTTTGTTAAGAGAGAACAAGATGATTGCAACAGCGAAAAAGAGA','4','9.76','Root; d__Archaea; p__Crenarchaeota; c__Thermoprotei; o__Sulfolobales; f__Sulfolobaceae; g__Metallosphaera; s__Metallosphaera_yellowstonensis'],
+                # 10 bp different from genome - unbinned
+                ['4.11.ribosomal_protein_L10','minimal','GGTAAAGCGAATCCAGCACCACCAGTTGGTCCAGCATTAGGTCAAGCAGGAAAAGGAGAA','4','9.76','Root; d__Bacteria; p__Firmicutes; c__Bacilli; o__Bacillales; f__Staphylococcaceae; g__Staphylococcus'],
+                # 10 bp different from genome - unbinned
+                ['4.14.ribosomal_protein_L16_L10E_rplP','minimal','ACGATCTTCCCGGACCGTCCGGTCACGAAGAAGCCGGCCGAGACCCGTCAAAAAAAAAAA','4','9.76','Root; d__Bacteria; p__Firmicutes; c__Bacilli; o__Bacillales; f__Staphylococcaceae; g__Staphylococcus'],
+                # 3 bp different from genome - unbinned
+                ['4.16.ribosomal_protein_S5','minimal','GGTACCGGCGTGATCGCGGGTGGGGGCGTCCGCGCCGTGCTCGAGCTGGCCGGGATTAAA','4','9.76','Root; d__Bacteria; p__Firmicutes; c__Bacilli; o__Bacillales; f__Staphylococcaceae; g__Staphylococcus'],
+                ""
+            ]
+            expected_unbinned = "\n".join(["\t".join(x) for x in expected_unbinned])
+
+            with open('binned.otu_table.tsv') as f:
+                observed_binned = "".join(f.readlines())
+            with open('unbinned.otu_table.tsv') as f:
+                observed_unbinned = "".join(f.readlines())
+
+            self.assertEqual(expected_binned, observed_binned)
+            self.assertEqual(expected_unbinned, observed_unbinned)
+
+
     def test_print_appraisal(self):
         metagenome_otu_table = [self.headers,
                     ['4.12.ribosomal_protein_L11_rplK','minimal','GGTAAAGCGAATCCAGCACCACCAGTTGGTCCAGCATTAGGTCAAGCAGGTGTGAACATC','7','17.07','Root; d__Bacteria; p__Firmicutes; c__Bacilli; o__Bacillales'],

--- a/test/test_appraise.py
+++ b/test/test_appraise.py
@@ -39,6 +39,7 @@ from singlem.appraiser import Appraiser
 from singlem.otu_table_collection import OtuTableCollection
 from singlem.otu_table import OtuTable
 from singlem.metapackage import Metapackage
+from singlem.appraiser import AppraiseMaxDivergenceCutoffs
 
 class Tests(unittest.TestCase):
     headers = str.split('gene sample sequence num_hits coverage taxonomy')
@@ -408,6 +409,81 @@ class Tests(unittest.TestCase):
         self.assertEqual('minimal', a.metagenome_sample_name)
         self.assertEqual({'d__Archaea': 7, 'd__Bacteria': 7}, a.num_binned)
         self.assertEqual({'d__Archaea': 4, 'd__Bacteria': 4}, a.num_not_found)
+
+
+    def test_clusterer_taxa_level(self):
+        taxa_level_cutoffs = AppraiseMaxDivergenceCutoffs({
+            "4.11.ribosomal_protein_L10": {"d__Archaea": 6, "d__Bacteria": 8},
+            "4.12.ribosomal_protein_L11_rplK": {"d__Archaea": 6, "d__Bacteria": 8},
+            "4.14.ribosomal_protein_L16_L10E_rplP": {"d__Archaea": 4, "d__Bacteria": 2},
+            "4.16.ribosomal_protein_S5": {"d__Archaea": 4, "d__Bacteria": 2},
+        })
+
+        metagenome_otu_table = [self.headers,
+                    # one bp different from genome - binned
+                    ['4.11.ribosomal_protein_L10','minimal','TGCGGCGGCGCCAACGGCGAGGCCGGAGCGGTCCGCCTCGGCATCGCCCGCGCGCTCGTG','7','17.07','Root; d__Archaea; p__Crenarchaeota; c__Thermoprotei; o__Sulfolobales; f__Sulfolobaceae'],
+                    # 10 bp different from genome - unbinned
+                    ['4.11.ribosomal_protein_L10','minimal','TGCGGCGGCGCCAACGGCGAGGCCGGAGCGGTCCGCCTCGGCATCGCCCGAAAAAAAAAA','4','9.76','Root; d__Archaea; p__Crenarchaeota; c__Thermoprotei; o__Sulfolobales; f__Sulfolobaceae; g__Metallosphaera; s__Metallosphaera_yellowstonensis'],
+                    # one bp different from genome - binned
+                    ['4.12.ribosomal_protein_L11_rplK','minimal','ATTCCACTGCCGACCAAGAAGAGTACATTCACGGTTGTAAAAAGCCCGCATGTCTATAAA','7','17.07','Root; d__Archaea; p__Crenarchaeota; c__Thermoprotei; o__Sulfolobales; f__Sulfolobaceae'],
+                    # 7 bp different from genome - unbinned
+                    ['4.12.ribosomal_protein_L11_rplK','minimal','ATTCCACTGCCGACCAAGAAGAGTACATTCACGGTTGTAAAAAGCCCGCATGTAAGAGGG','4','9.76','Root; d__Archaea; p__Crenarchaeota; c__Thermoprotei; o__Sulfolobales; f__Sulfolobaceae; g__Metallosphaera; s__Metallosphaera_yellowstonensis'],
+                    # one bp different from genome - binned
+                    ['4.14.ribosomal_protein_L16_L10E_rplP','minimal','AGAGTATATCCACACATTTTGTTAAGAGAGAACAAGATGATTGCAACAGCAGGTGCAGAC','7','17.07','Root; d__Archaea; p__Crenarchaeota; c__Thermoprotei; o__Sulfolobales; f__Sulfolobaceae'],
+                    # 10 bp different from genome - unbinned
+                    ['4.14.ribosomal_protein_L16_L10E_rplP','minimal','AGAGTATATCCACACATTTTGTTAAGAGAGAACAAGATGATTGCAACAGCGAAAAAGAGA','4','9.76','Root; d__Archaea; p__Crenarchaeota; c__Thermoprotei; o__Sulfolobales; f__Sulfolobaceae; g__Metallosphaera; s__Metallosphaera_yellowstonensis'],
+                    # one bp different from genome - binned
+                    ['4.16.ribosomal_protein_S5','minimal','GGATTAGGTCTTGTAGCAGGAGAAAACATAAAAAATCTATTAAAGCTTGCTGGTATTAAG','7','17.07','Root; d__Archaea; p__Crenarchaeota; c__Thermoprotei; o__Sulfolobales; f__Sulfolobaceae'],
+                    # 3 bp different from genome - binned
+                    ['4.16.ribosomal_protein_S5','minimal','GGATTAGGTCTTGTAGCAGGAGAAAACATAAAAAATCTATTAAAGCTTGCTGGTATTGGA','4','9.76','Root; d__Archaea; p__Crenarchaeota; c__Thermoprotei; o__Sulfolobales; f__Sulfolobaceae; g__Metallosphaera; s__Metallosphaera_yellowstonensis'],
+                    # one bp different from genome - binned
+                    ['4.11.ribosomal_protein_L10','minimal','GGTAAAGCGAATCCAGCACCACCAGTTGGTCCAGCATTAGGTCAAGCAGGTGTGAACATC','7','17.07','Root; d__Bacteria; p__Firmicutes; c__Bacilli; o__Bacillales'],
+                    # 10 bp different from genome - unbinned
+                    ['4.11.ribosomal_protein_L10','minimal','GGTAAAGCGAATCCAGCACCACCAGTTGGTCCAGCATTAGGTCAAGCAGGAAAAGGAGAA','4','9.76','Root; d__Bacteria; p__Firmicutes; c__Bacilli; o__Bacillales; f__Staphylococcaceae; g__Staphylococcus'],
+                    # one bp different from genome - binned
+                    ['4.12.ribosomal_protein_L11_rplK','minimal','CCGGGAGGGAAAGTGAACCCCGCTCCTCCAATCGGGCCGGCGCTCGGCCAGCACGGCGTC','7','17.07','Root; d__Bacteria; p__Firmicutes; c__Bacilli; o__Bacillales'],
+                    # 7 bp different from genome - binned
+                    ['4.12.ribosomal_protein_L11_rplK','minimal','CCGGGAGGGAAAGTGAACCCCGCTCCTCCAATCGGGCCGGCGCTCGGCCAGCAAAAAAAA','4','9.76','Root; d__Bacteria; p__Firmicutes; c__Bacilli; o__Bacillales; f__Staphylococcaceae; g__Staphylococcus'],
+                    # one bp different from genome - binned
+                    ['4.14.ribosomal_protein_L16_L10E_rplP','minimal','ACGATCTTCCCGGACCGTCCGGTCACGAAGAAGCCGGCCGAGACCCGTCAGGGTTCGGGG','7','17.07','Root; d__Bacteria; p__Firmicutes; c__Bacilli; o__Bacillales'],
+                    # 10 bp different from genome - unbinned
+                    ['4.14.ribosomal_protein_L16_L10E_rplP','minimal','ACGATCTTCCCGGACCGTCCGGTCACGAAGAAGCCGGCCGAGACCCGTCAAAAAAAAAAA','4','9.76','Root; d__Bacteria; p__Firmicutes; c__Bacilli; o__Bacillales; f__Staphylococcaceae; g__Staphylococcus'],
+                    # one bp different from genome - binned
+                    ['4.16.ribosomal_protein_S5','minimal','GGTACCGGCGTGATCGCGGGTGGGGGCGTCCGCGCCGTGCTCGAGCTGGCCGGGATTCGC','7','17.07','Root; d__Bacteria; p__Firmicutes; c__Bacilli; o__Bacillales'],
+                    # 3 bp different from genome - unbinned
+                    ['4.16.ribosomal_protein_S5','minimal','GGTACCGGCGTGATCGCGGGTGGGGGCGTCCGCGCCGTGCTCGAGCTGGCCGGGATTAAA','4','9.76','Root; d__Bacteria; p__Firmicutes; c__Bacilli; o__Bacillales; f__Staphylococcaceae; g__Staphylococcus'],
+                    ]
+        metagenomes = "\n".join(["\t".join(x) for x in metagenome_otu_table])
+
+        genomes_otu_table = [self.headers,
+                    ['4.11.ribosomal_protein_L10','genome_1','GGTAAAGCGAATCCAGCACCACCAGTTGGTCCAGCATTAGGTCAAGCAGGTGTGAACATT','1','1.02','Root; d__Bacteria; p__Firmicutes; c__Bacilli'],
+                    ['4.11.ribosomal_protein_L10','genome_2','TGCGGCGGCGCCAACGGCGAGGCCGGAGCGGTCCGCCTCGGCATCGCCCGCGCGCTCGTT','1','1.02','Root; d__Archaea; p__Crenarchaeota; c__Thermoprotei'],
+                    ['4.12.ribosomal_protein_L11_rplK','genome_1','CCGGGAGGGAAAGTGAACCCCGCTCCTCCAATCGGGCCGGCGCTCGGCCAGCACGGCGTT','1','1.02','Root; d__Bacteria; p__Firmicutes; c__Bacilli'],
+                    ['4.12.ribosomal_protein_L11_rplK','genome_2','ATTCCACTGCCGACCAAGAAGAGTACATTCACGGTTGTAAAAAGCCCGCATGTCTATAAT','1','1.02','Root; d__Archaea; p__Crenarchaeota; c__Thermoprotei'],
+                    ['4.14.ribosomal_protein_L16_L10E_rplP','genome_1','ACGATCTTCCCGGACCGTCCGGTCACGAAGAAGCCGGCCGAGACCCGTCAGGGTTCGGGT','1','1.02','Root; d__Bacteria; p__Firmicutes; c__Bacilli'],
+                    ['4.14.ribosomal_protein_L16_L10E_rplP','genome_2','AGAGTATATCCACACATTTTGTTAAGAGAGAACAAGATGATTGCAACAGCAGGTGCAGAT','1','1.02','Root; d__Archaea; p__Crenarchaeota; c__Thermoprotei'],
+                    ['4.16.ribosomal_protein_S5','genome_1','GGTACCGGCGTGATCGCGGGTGGGGGCGTCCGCGCCGTGCTCGAGCTGGCCGGGATTCGT','1','1.02','Root; d__Bacteria; p__Firmicutes; c__Bacilli'],
+                    ['4.16.ribosomal_protein_S5','genome_2','GGATTAGGTCTTGTAGCAGGAGAAAACATAAAAAATCTATTAAAGCTTGCTGGTATTAAT','1','1.02','Root; d__Archaea; p__Crenarchaeota; c__Thermoprotei'],
+                    ]
+        genomes = "\n".join(["\t".join(x) for x in genomes_otu_table])
+
+        appraiser = Appraiser()
+        metagenome_collection = OtuTableCollection()
+        metagenome_collection.add_otu_table(StringIO(metagenomes))
+        genome_collection = OtuTableCollection()
+        genome_collection.add_otu_table(StringIO(genomes))
+        packages = Metapackage.acquire(os.path.join(path_to_data, 'four_package.smpkg')).singlem_packages
+        app = appraiser.appraise(genome_otu_table_collection=genome_collection,
+                                 metagenome_otu_table_collection=metagenome_collection,
+                                 imperfect=True,
+                                 taxa_level_cutoffs=taxa_level_cutoffs,
+                                 packages=packages,
+                                 window_size=DEFAULT_WINDOW_SIZE)
+        self.assertEqual(1, len(app.appraisal_results))
+        a = app.appraisal_results[0]
+        self.assertEqual('minimal', a.metagenome_sample_name)
+        self.assertEqual({'d__Archaea': round(sum([7, 7, 7, 11]) / 4), 'd__Bacteria': round(sum([7, 11, 7, 7]) / 4)}, a.num_binned)
+        self.assertEqual({'d__Archaea': round(sum([4, 4, 4, 0]) / 4), 'd__Bacteria': round(sum([4, 0, 4, 4]) / 4)}, a.num_not_found)
 
 
     def test_print_appraisal(self):

--- a/test/test_appraise.py
+++ b/test/test_appraise.py
@@ -197,6 +197,7 @@ class Tests(unittest.TestCase):
         packages = Metapackage.acquire(os.path.join(path_to_data, 'four_package.smpkg')).singlem_packages
         app = appraiser.appraise(genome_otu_table_collection=genome_collection,
                                  metagenome_otu_table_collection=metagenome_collection,
+                                 imperfect=True,
                                  sequence_identity=0.5,
                                  packages=packages,
                                  window_size=DEFAULT_WINDOW_SIZE)
@@ -226,6 +227,7 @@ class Tests(unittest.TestCase):
         packages = Metapackage.acquire(os.path.join(path_to_data, 'four_package.smpkg')).singlem_packages
         app = appraiser.appraise(genome_otu_table_collection=genome_collection,
                                  metagenome_otu_table_collection=metagenome_collection,
+                                 imperfect=True,
                                  sequence_identity=0.7,
                                  packages=packages,
                                  window_size=DEFAULT_WINDOW_SIZE)
@@ -255,6 +257,7 @@ class Tests(unittest.TestCase):
         packages = Metapackage.acquire(os.path.join(path_to_data, 'four_package.smpkg')).singlem_packages
         app = appraiser.appraise(genome_otu_table_collection=genome_collection,
                                  metagenome_otu_table_collection=metagenome_collection,
+                                 imperfect=True,
                                  sequence_identity=0.7,
                                  packages=packages,
                                  window_size=DEFAULT_WINDOW_SIZE)
@@ -302,6 +305,7 @@ class Tests(unittest.TestCase):
         packages = Metapackage.acquire(os.path.join(path_to_data, 'four_package.smpkg')).singlem_packages
         app = appraiser.appraise(genome_otu_table_collection=genome_collection,
                                  metagenome_otu_table_collection=metagenome_collection,
+                                 imperfect=True,
                                  sequence_identity=0.7,
                                  packages=packages,
                                  window_size=DEFAULT_WINDOW_SIZE)
@@ -395,6 +399,7 @@ class Tests(unittest.TestCase):
         packages = Metapackage.acquire(os.path.join(path_to_data, 'four_package.smpkg')).singlem_packages
         app = appraiser.appraise(genome_otu_table_collection=genome_collection,
                                  metagenome_otu_table_collection=metagenome_collection,
+                                 imperfect=True,
                                  sequence_identity=0.9,
                                  packages=packages,
                                  window_size=DEFAULT_WINDOW_SIZE)
@@ -900,6 +905,7 @@ class Tests(unittest.TestCase):
         packages = Metapackage.acquire(os.path.join(path_to_data, 'four_package.smpkg')).singlem_packages
         app = appraiser.appraise(genome_otu_table_collection=genome_collection,
                                  metagenome_otu_table_collection=metagenome_collection,
+                                 imperfect=True,
                                  sequence_identity=0.9,
                                  packages=packages,
                                  window_size=DEFAULT_WINDOW_SIZE)
@@ -1129,6 +1135,7 @@ class Tests(unittest.TestCase):
         app = appraiser.appraise(genome_otu_table_collection=genome_collection,
                                  metagenome_otu_table_collection=metagenome_collection,
                                  assembly_otu_table_collection=assembly_collection,
+                                 imperfect=True,
                                  sequence_identity=0.9,
                                  packages=packages,
                                  window_size=DEFAULT_WINDOW_SIZE)

--- a/test/test_appraise.py
+++ b/test/test_appraise.py
@@ -337,6 +337,74 @@ class Tests(unittest.TestCase):
         self.assertEqual('maximal',
                          a.not_found_otus[0].sample_name)
 
+
+    def test_clusterer_both_domains(self):
+        metagenome_otu_table = [self.headers,
+                    # one bp different from genome
+                    ['4.11.ribosomal_protein_L10','minimal','GGTAAAGCGAATCCAGCACCACCAGTTGGTCCAGCATTAGGTCAAGCAGGTGTGAACATC','7','17.07','Root; d__Bacteria; p__Firmicutes; c__Bacilli; o__Bacillales'],
+                    # 10 bp different from genome
+                    ['4.11.ribosomal_protein_L10','minimal','GGTAAAGCGAATCCAGCACCACCAGTTGGTCCAGCATTAGGTCAAGCAGGAAAAAAAAAA','4','9.76','Root; d__Bacteria; p__Firmicutes; c__Bacilli; o__Bacillales; f__Staphylococcaceae; g__Staphylococcus'],
+                    # one bp different from genome
+                    ['4.11.ribosomal_protein_L10','minimal','TGCGGCGGCGCCAACGGCGAGGCCGGAGCGGTCCGCCTCGGCATCGCCCGCGCGCTCGTG','7','17.07','Root; d__Archaea; p__Crenarchaeota; c__Thermoprotei; o__Sulfolobales; f__Sulfolobaceae'],
+                    # 10 bp different from genome
+                    ['4.11.ribosomal_protein_L10','minimal','TGCGGCGGCGCCAACGGCGAGGCCGGAGCGGTCCGCCTCGGCATCGCCCGAAAAAAAAAA','4','9.76','Root; d__Archaea; p__Crenarchaeota; c__Thermoprotei; o__Sulfolobales; f__Sulfolobaceae; g__Metallosphaera; s__Metallosphaera_yellowstonensis'],
+                    # one bp different from genome
+                    ['4.12.ribosomal_protein_L11_rplK','minimal','CCGGGAGGGAAAGTGAACCCCGCTCCTCCAATCGGGCCGGCGCTCGGCCAGCACGGCGTC','7','17.07','Root; d__Bacteria; p__Firmicutes; c__Bacilli; o__Bacillales'],
+                    # 10 bp different from genome
+                    ['4.12.ribosomal_protein_L11_rplK','minimal','CCGGGAGGGAAAGTGAACCCCGCTCCTCCAATCGGGCCGGCGCTCGGCCAAAAAAAAAAA','4','9.76','Root; d__Bacteria; p__Firmicutes; c__Bacilli; o__Bacillales; f__Staphylococcaceae; g__Staphylococcus'],
+                    # one bp different from genome
+                    ['4.12.ribosomal_protein_L11_rplK','minimal','ATTCCACTGCCGACCAAGAAGAGTACATTCACGGTTGTAAAAAGCCCGCATGTCTATAAA','7','17.07','Root; d__Archaea; p__Crenarchaeota; c__Thermoprotei; o__Sulfolobales; f__Sulfolobaceae'],
+                    # 10 bp different from genome
+                    ['4.12.ribosomal_protein_L11_rplK','minimal','ATTCCACTGCCGACCAAGAAGAGTACATTCACGGTTGTAAAAAGCCCGCAAAAAAAAAAA','4','9.76','Root; d__Archaea; p__Crenarchaeota; c__Thermoprotei; o__Sulfolobales; f__Sulfolobaceae; g__Metallosphaera; s__Metallosphaera_yellowstonensis'],
+                    # one bp different from genome
+                    ['4.14.ribosomal_protein_L16_L10E_rplP','minimal','ACGATCTTCCCGGACCGTCCGGTCACGAAGAAGCCGGCCGAGACCCGTCAGGGTTCGGGG','7','17.07','Root; d__Bacteria; p__Firmicutes; c__Bacilli; o__Bacillales'],
+                    # 10 bp different from genome
+                    ['4.14.ribosomal_protein_L16_L10E_rplP','minimal','ACGATCTTCCCGGACCGTCCGGTCACGAAGAAGCCGGCCGAGACCCGTCAAAAAAAAAAA','4','9.76','Root; d__Bacteria; p__Firmicutes; c__Bacilli; o__Bacillales; f__Staphylococcaceae; g__Staphylococcus'],
+                    # one bp different from genome
+                    ['4.14.ribosomal_protein_L16_L10E_rplP','minimal','AGAGTATATCCACACATTTTGTTAAGAGAGAACAAGATGATTGCAACAGCAGGTGCAGAC','7','17.07','Root; d__Archaea; p__Crenarchaeota; c__Thermoprotei; o__Sulfolobales; f__Sulfolobaceae'],
+                    # 10 bp different from genome
+                    ['4.14.ribosomal_protein_L16_L10E_rplP','minimal','AGAGTATATCCACACATTTTGTTAAGAGAGAACAAGATGATTGCAACAGCAAAAAAAAAA','4','9.76','Root; d__Archaea; p__Crenarchaeota; c__Thermoprotei; o__Sulfolobales; f__Sulfolobaceae; g__Metallosphaera; s__Metallosphaera_yellowstonensis'],
+                    # one bp different from genome
+                    ['4.16.ribosomal_protein_S5','minimal','GGTACCGGCGTGATCGCGGGTGGGGGCGTCCGCGCCGTGCTCGAGCTGGCCGGGATTCGC','7','17.07','Root; d__Bacteria; p__Firmicutes; c__Bacilli; o__Bacillales'],
+                    # 10 bp different from genome
+                    ['4.16.ribosomal_protein_S5','minimal','GGTACCGGCGTGATCGCGGGTGGGGGCGTCCGCGCCGTGCTCGAGCTGGCAAAAAAAAAA','4','9.76','Root; d__Bacteria; p__Firmicutes; c__Bacilli; o__Bacillales; f__Staphylococcaceae; g__Staphylococcus'],
+                    # one bp different from genome
+                    ['4.16.ribosomal_protein_S5','minimal','GGATTAGGTCTTGTAGCAGGAGAAAACATAAAAAATCTATTAAAGCTTGCTGGTATTAAG','7','17.07','Root; d__Archaea; p__Crenarchaeota; c__Thermoprotei; o__Sulfolobales; f__Sulfolobaceae'],
+                    # 10 bp different from genome
+                    ['4.16.ribosomal_protein_S5','minimal','GGATTAGGTCTTGTAGCAGGAGAAAACATAAAAAATCTATTAAAGCTTGCAAAAAAAAAA','4','9.76','Root; d__Archaea; p__Crenarchaeota; c__Thermoprotei; o__Sulfolobales; f__Sulfolobaceae; g__Metallosphaera; s__Metallosphaera_yellowstonensis'],
+                    ]
+        metagenomes = "\n".join(["\t".join(x) for x in metagenome_otu_table])
+
+        genomes_otu_table = [self.headers,
+                    ['4.11.ribosomal_protein_L10','genome_1','GGTAAAGCGAATCCAGCACCACCAGTTGGTCCAGCATTAGGTCAAGCAGGTGTGAACATT','1','1.02','Root; d__Bacteria; p__Firmicutes; c__Bacilli'],
+                    ['4.11.ribosomal_protein_L10','genome_2','TGCGGCGGCGCCAACGGCGAGGCCGGAGCGGTCCGCCTCGGCATCGCCCGCGCGCTCGTT','1','1.02','Root; d__Archaea; p__Crenarchaeota; c__Thermoprotei'],
+                    ['4.12.ribosomal_protein_L11_rplK','genome_1','CCGGGAGGGAAAGTGAACCCCGCTCCTCCAATCGGGCCGGCGCTCGGCCAGCACGGCGTT','1','1.02','Root; d__Bacteria; p__Firmicutes; c__Bacilli'],
+                    ['4.12.ribosomal_protein_L11_rplK','genome_2','ATTCCACTGCCGACCAAGAAGAGTACATTCACGGTTGTAAAAAGCCCGCATGTCTATAAT','1','1.02','Root; d__Archaea; p__Crenarchaeota; c__Thermoprotei'],
+                    ['4.14.ribosomal_protein_L16_L10E_rplP','genome_1','ACGATCTTCCCGGACCGTCCGGTCACGAAGAAGCCGGCCGAGACCCGTCAGGGTTCGGGT','1','1.02','Root; d__Bacteria; p__Firmicutes; c__Bacilli'],
+                    ['4.14.ribosomal_protein_L16_L10E_rplP','genome_2','AGAGTATATCCACACATTTTGTTAAGAGAGAACAAGATGATTGCAACAGCAGGTGCAGAT','1','1.02','Root; d__Archaea; p__Crenarchaeota; c__Thermoprotei'],
+                    ['4.16.ribosomal_protein_S5','genome_1','GGTACCGGCGTGATCGCGGGTGGGGGCGTCCGCGCCGTGCTCGAGCTGGCCGGGATTCGT','1','1.02','Root; d__Bacteria; p__Firmicutes; c__Bacilli'],
+                    ['4.16.ribosomal_protein_S5','genome_2','GGATTAGGTCTTGTAGCAGGAGAAAACATAAAAAATCTATTAAAGCTTGCTGGTATTAAT','1','1.02','Root; d__Archaea; p__Crenarchaeota; c__Thermoprotei'],
+                    ]
+        genomes = "\n".join(["\t".join(x) for x in genomes_otu_table])
+
+        appraiser = Appraiser()
+        metagenome_collection = OtuTableCollection()
+        metagenome_collection.add_otu_table(StringIO(metagenomes))
+        genome_collection = OtuTableCollection()
+        genome_collection.add_otu_table(StringIO(genomes))
+        packages = Metapackage.acquire(os.path.join(path_to_data, 'four_package.smpkg')).singlem_packages
+        app = appraiser.appraise(genome_otu_table_collection=genome_collection,
+                                 metagenome_otu_table_collection=metagenome_collection,
+                                 sequence_identity=0.9,
+                                 packages=packages,
+                                 window_size=DEFAULT_WINDOW_SIZE)
+        self.assertEqual(1, len(app.appraisal_results))
+        a = app.appraisal_results[0]
+        self.assertEqual('minimal', a.metagenome_sample_name)
+        self.assertEqual({'d__Archaea': 7, 'd__Bacteria': 7}, a.num_binned)
+        self.assertEqual({'d__Archaea': 4, 'd__Bacteria': 4}, a.num_not_found)
+
+
     def test_print_appraisal(self):
         metagenome_otu_table = [self.headers,
                     ['4.12.ribosomal_protein_L11_rplK','minimal','GGTAAAGCGAATCCAGCACCACCAGTTGGTCCAGCATTAGGTCAAGCAGGTGTGAACATC','7','17.07','Root; d__Bacteria; p__Firmicutes; c__Bacilli; o__Bacillales'],

--- a/test/test_appraise.py
+++ b/test/test_appraise.py
@@ -413,11 +413,13 @@ class Tests(unittest.TestCase):
 
     def test_clusterer_taxa_level(self):
         taxa_level_cutoffs = AppraiseMaxDivergenceCutoffs({
-            "4.11.ribosomal_protein_L10": {"d__Archaea": 6, "d__Bacteria": 8},
-            "4.12.ribosomal_protein_L11_rplK": {"d__Archaea": 6, "d__Bacteria": 8},
-            "4.14.ribosomal_protein_L16_L10E_rplP": {"d__Archaea": 4, "d__Bacteria": 2},
-            "4.16.ribosomal_protein_S5": {"d__Archaea": 4, "d__Bacteria": 2},
-        })
+            "4.11.ribosomal_protein_L10": {"d__Archaea": 0.89, "d__Bacteria": 0.86},
+            "4.12.ribosomal_protein_L11_rplK": {"d__Archaea": 0.89, "d__Bacteria": 0.86},
+            "4.14.ribosomal_protein_L16_L10E_rplP": {"d__Archaea": 0.93, "d__Bacteria": 0.96},
+            "4.16.ribosomal_protein_S5": {"d__Archaea": 0.93, "d__Bacteria": 0.96},
+            },
+            window_size=DEFAULT_WINDOW_SIZE
+            )
 
         metagenome_otu_table = [self.headers,
                     # one bp different from genome - binned


### PR DESCRIPTION
~~Implement `get_max_divergence`, taking package, domain and cutoff taxa level (e.g. genus) and returns max divergence~~
- [x] Implement object `taxa_level_cutoffs` with values for each package-domain (so set at a taxa level)
- [x] Split `_appraise_inexactly` querying into each package-domain, retrieving `max_divergence` for each combination