### PR TITLE
Multithread appraise

### DIFF
--- a/singlem/appraiser.py
+++ b/singlem/appraiser.py
@@ -36,6 +36,7 @@ class Appraiser:
         sequence_identity = kwargs.pop('sequence_identity', None)
         output_found_in = kwargs.pop('output_found_in', False)
         window_size = kwargs.pop('window_size')
+        threads = kwargs.pop('threads', 1)
         if len(kwargs) > 0:
             raise Exception("Unexpected arguments detected: %s" % kwargs)
 
@@ -62,7 +63,8 @@ class Appraiser:
                 sequence_identity,
                 output_found_in,
                 packages,
-                window_size)
+                window_size,
+                threads)
             sample_to_building_block = sample_to_binned
         if assembly_otu_table_collection:
             sample_to_assembled = self._appraise_inexactly(
@@ -71,7 +73,8 @@ class Appraiser:
                 sequence_identity,
                 output_found_in,
                 packages,
-                window_size)
+                window_size,
+                threads)
             sample_to_building_block = sample_to_assembled
 
         app = Appraisal()
@@ -112,7 +115,8 @@ class Appraiser:
                             sequence_identity,
                             output_found_in,
                             packages,
-                            window_size):
+                            window_size,
+                            threads):
         '''Given a metagenome sample collection and OTUs 'found' either by binning or
         assembly, return a AppraisalBuildingBlock representing the OTUs that
         have been found, using inexact matching.
@@ -151,7 +155,7 @@ class Appraiser:
             metagenome_collection.sort_otu_tables_by_marker()
 
         querier = Querier()
-        queries = querier.query_with_queries(metagenome_collection, sdb_tmp, max_divergence, SMAFA_NAIVE_INDEX_FORMAT, SequenceDatabase.NUCLEOTIDE_TYPE, 1, None, False, None)
+        queries = querier.query_with_queries(metagenome_collection, sdb_tmp, max_divergence, SMAFA_NAIVE_INDEX_FORMAT, SequenceDatabase.NUCLEOTIDE_TYPE, 1, None, False, None, threads)
 
         sample_to_building_block = {}
         for hit in queries:

--- a/singlem/main.py
+++ b/singlem/main.py
@@ -254,6 +254,8 @@ def main():
     appraise_otu_table_options.add_argument('--assembly-otu-tables', nargs='+', help="output of 'pipe' run on assembled sequence")
     appraise_otu_table_options.add_argument('--assembly-archive-otu-tables', nargs='+', help="archive output of 'pipe' run on assembled sequence")
     appraise_otu_table_options.add_argument('--metapackage', help='Metapackage used in the creation of the OTU tables')
+    current_default = 1
+    appraise_otu_table_options.add_argument('--threads', help='Use this many threads where possible [default %i]' % current_default, default=current_default)
     appraise_inexact_options = appraise_parser.add_argument_group('Inexact appraisal options')
     appraise_inexact_options.add_argument('--imperfect', action='store_true', help="use sequence searching to account for genomes that are similar to those found in the metagenome [default: False]", default=False)
     appraise_inexact_options.add_argument('--sequence-identity', type=float, help="sequence identity cutoff to use if --imperfect is specified [default: ~species level divergence i.e. %s]" % SPECIES_LEVEL_AVERAGE_IDENTITY, default=SPECIES_LEVEL_AVERAGE_IDENTITY)
@@ -1138,7 +1140,9 @@ def main():
                                 output_found_in = args.output_found_in,
                                 sequence_identity=(args.sequence_identity if args.imperfect else None),
                                 packages=pkgs,
-                                window_size=DEFAULT_WINDOW_SIZE)
+                                window_size=DEFAULT_WINDOW_SIZE,
+                                threads=args.threads,
+                                )
 
         if args.output_binned_otu_table:
             output_binned_otu_table_io = open(args.output_binned_otu_table,'w')

--- a/singlem/querier.py
+++ b/singlem/querier.py
@@ -387,7 +387,7 @@ class Querier:
                     raise Exception("Unexpected sequence_type")
             
             # Actually do searches, in batches
-            for chunked_queries1 in iterable_chunks(marker_queries, 1000):
+            for chunked_queries1 in iterable_chunks(marker_queries, 1_000_000):
                 chunked_queries = list([a for a in chunked_queries1 if a is not None]) # Remove trailing Nones from the iterable
 
                 if sequence_type == SequenceDatabase.NUCLEOTIDE_TYPE:

--- a/test/test_appraise.py
+++ b/test/test_appraise.py
@@ -94,6 +94,7 @@ class Tests(unittest.TestCase):
                 "--metapackage {}/four_package.smpkg "
                 "--output-binned-otu-table binned.otu_table.tsv "
                 "--output-unaccounted-for-otu-table unbinned.otu_table.tsv "
+                "--threads 1 "
             ).format(
                 path_to_script,
                 path_to_data,


### PR DESCRIPTION
Applied to smafa search step

- [x] Switch to multithreading chunked query step
- [x] Large-scale test (~5% faster...)
- [x] Switch to providing smafa with threads
- [x] Large-scale test (~10% slower...)
- [x] Increase chunk size to 1M
- [x] Large-scale test (~2x faster)

Optional
- [ ] Switch to multithreading across marker genes