### PR TITLE
Nanopore

### DIFF
--- a/singlem/__main__.py
+++ b/singlem/__main__.py
@@ -1,0 +1,5 @@
+# singlem/__main__.py
+from .main import main
+
+if __name__ == "__main__":
+    main()

--- a/singlem/archive_otu_table.py
+++ b/singlem/archive_otu_table.py
@@ -126,6 +126,12 @@ class ArchiveOtuTableEntry(OtuTableEntry):
     
     def taxonomy_by_known(self):
         return self.data[ArchiveOtuTable.TAXONOMY_BY_KNOWN_FIELD_INDEX]
+    
+    def coverage(self):
+        return self.data[ArchiveOtuTable.COVERAGE_FIELD_INDEX]
+    
+    def taxonomy(self):
+        return self.data[ArchiveOtuTable.TAXONOMY_FIELD_INDEX]
 
 
 class InsufficientArchiveOtuTableVersionException(Exception):

--- a/singlem/condense.py
+++ b/singlem/condense.py
@@ -104,6 +104,7 @@ class Condenser:
                 raise Exception("Number of markers for all domains must either be >= 3 or equal to 0. Only {} markers for domain '{}' found".format(target_domains[domain], domain))
 
         for sample, sample_otus in input_otu_table.each_sample_otus(generate_archive_otu_table=True):
+
             logging.debug("Processing sample {} ..".format(sample))
             apply_diamond_expectation_maximisation = True
             yield self._condense_a_sample(sample, sample_otus, markers, target_domains, trim_percent, min_taxon_coverage, 
@@ -112,6 +113,7 @@ class Condenser:
     def _condense_a_sample(self, sample, sample_otus, markers, target_domains, trim_percent, min_taxon_coverage, 
             apply_query_expectation_maximisation, apply_diamond_expectation_maximisation, metapackage,
             output_after_em_otu_table):
+
 
         # Remove off-target OTUs genes
         logging.debug("Total OTU coverage by query: {}".format(sum([o.coverage for o in sample_otus if o.taxonomy_assignment_method() == QUERY_BASED_ASSIGNMENT_METHOD])))
@@ -122,6 +124,7 @@ class Condenser:
         logging.info("Total OTU coverage by query: {}".format(sum([o.coverage for o in sample_otus if o.taxonomy_assignment_method() == QUERY_BASED_ASSIGNMENT_METHOD])))
         logging.info("Total OTU coverage by diamond: {}".format(sum([o.coverage for o in sample_otus if o.taxonomy_assignment_method() == DIAMOND_ASSIGNMENT_METHOD])))
         # logging.info("Total coverage: {}".format(sum([o.coverage for o in sample_otus])))
+
 
         if apply_query_expectation_maximisation:
             sample_otus = self._apply_species_expectation_maximization(sample_otus, trim_percent, target_domains)
@@ -557,6 +560,8 @@ class Condenser:
         best_hit_taxonomy_sets = set()
         some_em_to_do = False
         species_genes = {}
+
+
         for otu in sample_otus:
             best_hit_taxonomies = otu.equal_best_hit_taxonomies()
             if otu.taxonomy_assignment_method() == QUERY_BASED_ASSIGNMENT_METHOD and best_hit_taxonomies is not None:

--- a/singlem/diamond_spkg_searcher.py
+++ b/singlem/diamond_spkg_searcher.py
@@ -1,11 +1,9 @@
 import os
 import logging
-import extern
 
 from subprocess import Popen, PIPE
 
 from .utils import FastaNameToSampleName
-from .run_via_os_system import run_via_os_system
 
 class DiamondSpkgSearcher:
     def __init__(self, num_threads, working_directory):
@@ -56,14 +54,13 @@ class DiamondSpkgSearcher:
         Array of DiamondSearchResult objects, one for each read file
         '''
         diamond_results = []
+
         if is_reverse_reads:
-            # running on reverse reads
             prefilter_dir = os.path.join(self._working_directory, 'prefilter_reverse')
         else:
             prefilter_dir = os.path.join(self._working_directory, 'prefilter_forward')
         os.mkdir(prefilter_dir)
 
-        is_long_read = True
         
         for file in read_files:
 
@@ -76,69 +73,8 @@ class DiamondSpkgSearcher:
             f = open(fasta_path, 'w+') # create tempfile in working directory
             f.close()
 
-            # #TODO: might get reid of the sed command and just use awk to print the first 3 columns
-            # # this used to be under --db %s:  "| tee >(sed 's/^/>/; s/\\t/\\n/; s/\\t.*//' > %s) " \
-            # cmd = "diamond blastx " \
-            #       "--outfmt 6 qseqid full_qseq sseqid " \
-            #       "--max-target-seqs 0 " \
-            #       "--evalue 0.01 " \
-            #       "%s " \
-            #       "--threads %i " \
-            #       "--query %s " \
-            #       "--db %s " \
-            #       "| awk '{print $1,$3,$2}'" % (
-            #           performance_parameters,
-            #           self._num_threads,
-            #           file,
-            #           diamond_database,
-            #         #   fasta_path # this is the output file for the tee command
-            #           )
-            # logging.debug(cmd)
-
-            # # Originially, we ran here via os.system rather than normal extern
-            # # so reads can be piped in to singlem. However, this meant that
-            # # errors and failed commands were ignored, sometimes causing
-            # # successful return of singlem but an empty OTU table.
-            # qseqid_sseqid = extern.run(cmd)
-            # best_hits = {}
-
-            # with open(fasta_path, 'a') as f:
-            #     for line in qseqid_sseqid.splitlines():
-            #         try:
-            #             (qseqid,sseqid,full_qseq) = line.split(' ')
-
-            #         except ValueError:
-            #             raise Exception("Unexpected line format for DIAMOND output line '{}'".format(line))
-                    
-            #         if is_long_read:
-            #             qseqid = qseqid + '~' + sseqid.split('~')[0]
-
-            #         # TODO: idk how important that last check is
-            #         # could maybe put in a bitscore check instead to ensure DIAMOND is outputing the best hits first
-            #         if qseqid in best_hits and best_hits[qseqid] != sseqid:
-            #             continue
-            #         # else:
-            #         #     if qseqid in best_hits and best_hits[qseqid] != sseqid:
-            #         #         raise Exception("Multiple DIAMOND best hits detected for '{}'. This likely indicates that the input reads have non-unique names, possibly due to the same read appearing twice in a single input file".format(qseqid))
-
-            #         best_hits[qseqid] = sseqid
-
-
-            #         f.write('>' + qseqid + '\n')
-            #         f.write(full_qseq + '\n')
-
-
-            # cmd = [
-            #     "diamond", "blastx",
-            #     "--outfmt", "6", "qseqid", "full_qseq", "sseqid",
-            #     "--max-target-seqs", "0",
-            #     "--evalue", "0.01",
-            #     "--threads", str(self._num_threads),
-            #     "--query", file,
-            #     "--db", diamond_database
-            # ]
-
-            # with range culling, etc
+            # DIAMOND command
+            # now with range culling, etc
             cmd = [ 
                 "diamond", "blastx",
                 "--outfmt", "6", "qseqid", "full_qseq", "sseqid",
@@ -156,6 +92,7 @@ class DiamondSpkgSearcher:
             logging.debug(' '.join(cmd))
 
             best_hits = {}
+            # using Popen to stream the output
             with Popen(cmd, stdout=PIPE, stderr=PIPE, text=True) as proc:
                 with open(fasta_path, 'a') as fasta_file:
                     for line in proc.stdout:
@@ -163,22 +100,21 @@ class DiamondSpkgSearcher:
                             qseqid, full_qseq, sseqid = line.strip().split('\t')
                         except ValueError:
                             raise Exception(f"Unexpected line format for DIAMOND output line '{line.strip()}'")
-                        
-                        # TODO: potentially remove after testing, might not be necessary to explicitly check for long reads
-                        if is_long_read:
-                            # for forcing the simulated sshort reads to be treated as long reads
-                            # if '-' in qseqid:
-                            #     qseqid = qseqid.split('-')[0]
+                    
+                        # creating new read index to account for multiple hits
+                        qseqid = qseqid + '~' + sseqid.split('~')[0]
 
-                            qseqid = qseqid + '~' + sseqid.split('~')[0]
-
+                        # DIAMOND shouldn't return the same qseqid twice, but just in case
                         if qseqid in best_hits:
                             continue
 
+                        # store the best hit for each query sequence
                         best_hits[qseqid] = sseqid
 
+                        # write the query sequence to a file
                         fasta_file.write(f'>{qseqid}\n{full_qseq}\n')    
 
+                # check for DIAMOND errors
                 stderr_output = proc.stderr.read()
                 if stderr_output:
                     logging.error(f"DIAMOND stderr: {stderr_output}")

--- a/singlem/diamond_spkg_searcher.py
+++ b/singlem/diamond_spkg_searcher.py
@@ -2,6 +2,8 @@ import os
 import logging
 import extern
 
+from subprocess import Popen, PIPE
+
 from .utils import FastaNameToSampleName
 from .run_via_os_system import run_via_os_system
 
@@ -60,8 +62,11 @@ class DiamondSpkgSearcher:
         else:
             prefilter_dir = os.path.join(self._working_directory, 'prefilter_forward')
         os.mkdir(prefilter_dir)
+
+        is_long_read = True
         
         for file in read_files:
+
             fasta_path = os.path.join(prefilter_dir,
                                       os.path.basename(file))
             if fasta_path[-3:] == '.gz':
@@ -70,41 +75,118 @@ class DiamondSpkgSearcher:
             
             f = open(fasta_path, 'w+') # create tempfile in working directory
             f.close()
-            
-            cmd = "diamond blastx " \
-                  "--outfmt 6 qseqid full_qseq sseqid " \
-                  "--max-target-seqs 1 " \
-                  "--evalue 0.01 " \
-                  "%s " \
-                  "--threads %i " \
-                  "--query %s " \
-                  "--db %s " \
-                  "| tee >(sed 's/^/>/; s/\\t/\\n/; s/\\t.*//' > %s) " \
-                  "| awk '{print $1,$3}'" % (
-                      performance_parameters,
-                      self._num_threads,
-                      file,
-                      diamond_database,
-                      fasta_path)
-            logging.debug(cmd)
 
-            # Originially, we ran here via os.system rather than normal extern
-            # so reads can be piped in to singlem. However, this meant that
-            # errors and failed commands were ignored, sometimes causing
-            # successful return of singlem but an empty OTU table.
-            qseqid_sseqid = extern.run(cmd)
+            # #TODO: might get reid of the sed command and just use awk to print the first 3 columns
+            # # this used to be under --db %s:  "| tee >(sed 's/^/>/; s/\\t/\\n/; s/\\t.*//' > %s) " \
+            # cmd = "diamond blastx " \
+            #       "--outfmt 6 qseqid full_qseq sseqid " \
+            #       "--max-target-seqs 0 " \
+            #       "--evalue 0.01 " \
+            #       "%s " \
+            #       "--threads %i " \
+            #       "--query %s " \
+            #       "--db %s " \
+            #       "| awk '{print $1,$3,$2}'" % (
+            #           performance_parameters,
+            #           self._num_threads,
+            #           file,
+            #           diamond_database,
+            #         #   fasta_path # this is the output file for the tee command
+            #           )
+            # logging.debug(cmd)
+
+            # # Originially, we ran here via os.system rather than normal extern
+            # # so reads can be piped in to singlem. However, this meant that
+            # # errors and failed commands were ignored, sometimes causing
+            # # successful return of singlem but an empty OTU table.
+            # qseqid_sseqid = extern.run(cmd)
+            # best_hits = {}
+
+            # with open(fasta_path, 'a') as f:
+            #     for line in qseqid_sseqid.splitlines():
+            #         try:
+            #             (qseqid,sseqid,full_qseq) = line.split(' ')
+
+            #         except ValueError:
+            #             raise Exception("Unexpected line format for DIAMOND output line '{}'".format(line))
+                    
+            #         if is_long_read:
+            #             qseqid = qseqid + '~' + sseqid.split('~')[0]
+
+            #         # TODO: idk how important that last check is
+            #         # could maybe put in a bitscore check instead to ensure DIAMOND is outputing the best hits first
+            #         if qseqid in best_hits and best_hits[qseqid] != sseqid:
+            #             continue
+            #         # else:
+            #         #     if qseqid in best_hits and best_hits[qseqid] != sseqid:
+            #         #         raise Exception("Multiple DIAMOND best hits detected for '{}'. This likely indicates that the input reads have non-unique names, possibly due to the same read appearing twice in a single input file".format(qseqid))
+
+            #         best_hits[qseqid] = sseqid
+
+
+            #         f.write('>' + qseqid + '\n')
+            #         f.write(full_qseq + '\n')
+
+
+            # cmd = [
+            #     "diamond", "blastx",
+            #     "--outfmt", "6", "qseqid", "full_qseq", "sseqid",
+            #     "--max-target-seqs", "0",
+            #     "--evalue", "0.01",
+            #     "--threads", str(self._num_threads),
+            #     "--query", file,
+            #     "--db", diamond_database
+            # ]
+
+            # with range culling, etc
+            cmd = [ 
+                "diamond", "blastx",
+                "--outfmt", "6", "qseqid", "full_qseq", "sseqid",
+                "--max-target-seqs", "0",
+                "--evalue", "0.01",
+                "--frameshift", "15",
+                "--range-culling",
+                "-k", "1",
+                "--threads", str(self._num_threads),
+                "--query", file,
+                "--db", diamond_database
+            ]
+
+            cmd.extend(performance_parameters.split())
+            logging.debug(' '.join(cmd))
+
             best_hits = {}
-            for line in qseqid_sseqid.splitlines():
-                try:
-                    (qseqid,sseqid) = line.split(' ')
-                except ValueError:
-                    raise Exception("Unexpected line format for DIAMOND output line '{}'".format(line))
-                if qseqid in best_hits and best_hits[qseqid] != sseqid:
-                    raise Exception("Multiple DIAMOND best hits detected for '{}'. This likely indicates that the input reads have non-unique names, possibly due to the same read appearing twice in a single input file".format(qseqid))
-                best_hits[qseqid] = sseqid
+            with Popen(cmd, stdout=PIPE, stderr=PIPE, text=True) as proc:
+                with open(fasta_path, 'a') as fasta_file:
+                    for line in proc.stdout:
+                        try:
+                            qseqid, full_qseq, sseqid = line.strip().split('\t')
+                        except ValueError:
+                            raise Exception(f"Unexpected line format for DIAMOND output line '{line.strip()}'")
+                        
+                        # TODO: potentially remove after testing, might not be necessary to explicitly check for long reads
+                        if is_long_read:
+                            # for forcing the simulated sshort reads to be treated as long reads
+                            # if '-' in qseqid:
+                            #     qseqid = qseqid.split('-')[0]
+
+                            qseqid = qseqid + '~' + sseqid.split('~')[0]
+
+                        if qseqid in best_hits:
+                            continue
+
+                        best_hits[qseqid] = sseqid
+
+                        fasta_file.write(f'>{qseqid}\n{full_qseq}\n')    
+
+                stderr_output = proc.stderr.read()
+                if stderr_output:
+                    logging.error(f"DIAMOND stderr: {stderr_output}")
+                    raise Exception("DIAMOND failed")
+            
 
             diamond_results.append(DiamondSearchResult(fasta_path, best_hits))
-            
+
         return diamond_results
 
 class DiamondSearchResult:

--- a/singlem/main.py
+++ b/singlem/main.py
@@ -130,7 +130,8 @@ def main():
                     pipe.DIAMOND_ASSIGNMENT_METHOD,
                     pipe.DIAMOND_EXAMPLE_BEST_HIT_ASSIGNMENT_METHOD,
                     pipe.ANNOY_ASSIGNMENT_METHOD,
-                    pipe.PPLACER_ASSIGNMENT_METHOD),
+                    pipe.PPLACER_ASSIGNMENT_METHOD
+                    ),
             help='Method of assigning taxonomy to OTUs and taxonomic profiles [default: %s]\n\n' % (current_default) +
                 table_roff([
                     ["Method", "Description"],
@@ -205,6 +206,9 @@ def main():
                                     metavar='FLOAT',
                                     help='Minimum coverage to report in a taxonomic profile. [default: {} for reads, {} for genomes]'.format(CONDENSE_DEFAULT_MIN_TAXON_COVERAGE, CONDENSE_DEFAULT_GENOME_MIN_TAXON_COVERAGE),
                                     type=float)
+        argument_group.add_argument('--short-read-correction', 
+                                    help='adds a max read length to the coverage calculation to account for long reads', 
+                                    type=int, default=None)
 
     less_common_pipe_arguments = pipe_parser.add_argument_group('Less common options')
     add_less_common_pipe_arguments(less_common_pipe_arguments)
@@ -752,6 +756,7 @@ def main():
             exclude_off_target_hits = args.exclude_off_target_hits,
             min_taxon_coverage = get_min_taxon_coverage(args),
             max_species_divergence = args.max_species_divergence,
+            short_read_correction = args.short_read_correction
         )
 
     elif args.subparser_name=='renew':
@@ -778,6 +783,7 @@ def main():
             exclude_off_target_hits = args.exclude_off_target_hits,
             translation_table = args.translation_table,
             max_species_divergence = args.max_species_divergence,
+            short_read_correction = args.short_read_correction
             )
 
     elif args.subparser_name == 'summarise':

--- a/singlem/main.py
+++ b/singlem/main.py
@@ -156,9 +156,6 @@ def add_less_common_pipe_arguments(argument_group, extra_args=False):
                                 metavar='FLOAT',
                                 help='Minimum coverage to report in a taxonomic profile. [default: {} for reads, {} for genomes]'.format(CONDENSE_DEFAULT_MIN_TAXON_COVERAGE, CONDENSE_DEFAULT_GENOME_MIN_TAXON_COVERAGE),
                                 type=float)
-    argument_group.add_argument('--short-read-correction', 
-                            help='adds a max read length to the coverage calculation to account for long reads', 
-                            type=int, default=None)
     
     if extra_args:
         argument_group.add_argument('--working-directory', metavar='directory', help='use intermediate working directory at a specified location, and do not delete it upon completion [default: not set, use a temporary directory]')
@@ -761,8 +758,7 @@ def main():
             viral_profile_output = False,
             exclude_off_target_hits = args.exclude_off_target_hits,
             min_taxon_coverage = get_min_taxon_coverage(args),
-            max_species_divergence = args.max_species_divergence,
-            short_read_correction = args.short_read_correction
+            max_species_divergence = args.max_species_divergence
         )
 
     elif args.subparser_name=='renew':
@@ -788,8 +784,7 @@ def main():
             output_taxonomic_profile_krona = args.taxonomic_profile_krona,
             exclude_off_target_hits = args.exclude_off_target_hits,
             translation_table = args.translation_table,
-            max_species_divergence = args.max_species_divergence,
-            short_read_correction = args.short_read_correction
+            max_species_divergence = args.max_species_divergence
             )
 
     elif args.subparser_name == 'summarise':

--- a/singlem/pipe.py
+++ b/singlem/pipe.py
@@ -1442,24 +1442,6 @@ class SearchPipe:
                             still_unknown_sequences = \
                                 [u for u in readset.unknown_sequences if not \
                                     query_based_assignment_result.is_assigned_taxonomy(singlem_package, readset.sample_name, u.name, None)]
-                            
-                            # known_sequences = [u for u in readset.unknown_sequences if u not in still_unknown_sequences]
-
-                            # with open('unknown_sequences', 'w') as f:
-                            #     for u in still_unknown_sequences:
-                            #         f.write(">")
-                            #         f.write(u.name)
-                            #         f.write("\n")
-                            #         f.write(u.unaligned_sequence)
-                            #         f.write("\n")
-
-                            # with open('known_sequences', 'w') as f:
-                            #     for u in known_sequences:
-                            #         f.write(">")
-                            #         f.write(u.name)
-                            #         f.write("\n")
-                            #         f.write(u.unaligned_sequence)
-                            #         f.write("\n")
 
                             logging.info("Assigning taxonomy with DIAMOND for {} out of {} sequences ({:.1f}%) for sample {}, package {}".format(
                                 len(still_unknown_sequences),

--- a/singlem/pipe.py
+++ b/singlem/pipe.py
@@ -1657,17 +1657,11 @@ class SearchPipe:
         choosing as the right one the one that has the least gaps.'''
 
         names = [unknown_sequence.name for unknown_sequence in readset.unknown_sequences]
-        # TODO: This is a hack to remove the ~1, ~2, etc. suffixes for the simulated short reads,
-        # remove after testing
-        names = [name.split('~')[0] + '~' + name.split('~')[-1] for name in names]
         
         if len(set(names)) < len(names):
             unknown_sequences_to_keep = {}
             for seq_obj in readset.unknown_sequences:
                 name = seq_obj.name
-                # TODO: This is a hack to remove the ~1, ~2, etc. suffixes for the simulated short reads,
-                # remove after testing
-                # name = name.split('~')[0] + '~' + name.split('~')[-1]
   
                 if name not in unknown_sequences_to_keep:
                     unknown_sequences_to_keep[name] = seq_obj
@@ -1675,60 +1669,6 @@ class SearchPipe:
                     unknown_sequences_to_keep[name] = seq_obj
 
             readset.unknown_sequences = list(unknown_sequences_to_keep.values())
-
-        # if num_unique_names < len(readset.unknown_sequences):
-        #     logging.debug("Found at {} instance(s) where 2 different translations align to the 1 marker gene/window, removing duplicates.".format(
-        #         len(readset.unknown_sequences)-num_unique_names
-        #     ))
-
-        #     readname_to_otus = {}
-
-        # # gather all sequences for each readname
-        #     for unknown_sequence in readset.unknown_sequences:
-        #         try:
-        #             readname_to_otus[unknown_sequence.name].append(unknown_sequence.aligned_sequence)
-        #         except KeyError:
-        #             readname_to_otus[unknown_sequence.name] = [unknown_sequence.aligned_sequence]
-
-        #     to_delete = {}
-
-        # # iterate over readnames with multiple sequences
-        #     for (readname, window_sequences) in readname_to_otus.items():
-        #         if len(window_sequences) > 1:
-        #             min_gaps_otu = None
-
-        # # search for the sequence with the least gaps
-        #             for window_sequence in window_sequences:
-        
-        # # define the first sequence as the one with the least gaps
-        #                 if min_gaps_otu is None:
-        #                     min_gaps_otu = window_sequence
-
-        # # compare the number of gaps in the current sequence with the number of gaps in the previous min
-        #                 elif min_gaps_otu.count('-') > window_sequence.count('-'):
-        #                     # Mark previous min for deletion
-        # # 
-        #                     if min_gaps_otu in to_delete:
-        #                         to_delete[min_gaps_otu].append(readname)
-        #                     else:
-        #                         to_delete[min_gaps_otu] = [readname]
-        #                     min_gaps_otu = window_sequence
-        #                 else:
-        #                     # Mark current for deletion
-        #                     if window_sequence in to_delete:
-        #                         to_delete[window_sequence].append(readname)
-        #                     else:
-        #                         to_delete[window_sequence] = [readname]
-        
-        # # remove duplicates
-        #     readset.unknown_sequences = list(
-        #         [unknown_sequence for unknown_sequence in readset.unknown_sequences 
-        #             if not (
-        #                     unknown_sequence.aligned_sequence   in to_delete 
-        #                 and unknown_sequence.name               in to_delete[unknown_sequence.aligned_sequence])
-        #                 ])
-
-
 
 
 class SingleMPipeSearchResult:

--- a/singlem/pipe.py
+++ b/singlem/pipe.py
@@ -31,9 +31,6 @@ from graftm.greengenes_taxonomy import GreenGenesTaxonomy
 from graftm.sequence_search_results import HMMSearchResult, SequenceSearchResult
 
 
-# TODO: DELETE
-from memory_profiler import profile
-
 DEFAULT_THREADS = 1
 
 class SearchPipe:
@@ -76,7 +73,13 @@ class SearchPipe:
 
         otu_table_object = self.run_to_otu_table(**kwargs)
 
-        # HERE is some new stuff
+        # This snippet is for collapsing reads by their most common taxonomic 
+        # assignment.
+        # May be useful / more biologically accurate to do this instead of 
+        # treating each OTU as a separate entity.
+        # Preliminary testing shows that this has a negligible effect on the 
+        # final OTU table.
+
         # only using the query-based OTUs
         # might be better to use all and then pass on reassignment if DIAMOND is the mode
 
@@ -203,7 +206,7 @@ class SearchPipe:
             with open(archive_otu_table, 'w') as f:
                 otu_table_object.archive(metapackage).write_to(f)
 
-    # @profile
+
     def run_to_otu_table(self, **kwargs):
         '''Run the pipe'''
         forward_read_files = kwargs.pop('sequences', [])
@@ -237,10 +240,6 @@ class SearchPipe:
         diamond_taxonomy_assignment_performance_parameters = kwargs.pop('diamond_taxonomy_assignment_performance_parameters', None)
         assignment_singlem_db = kwargs.pop('assignment_singlem_db', None)
         max_species_divergence = kwargs.pop('max_species_divergence', SearchPipe.DEFAULT_MAX_SPECIES_DIVERGENCE)
-
-        # TODO: make not globaL once tested
-        global SHORT_READ_CORRECTION
-        SHORT_READ_CORRECTION = kwargs.pop('short_read_correction', None)
 
         working_directory = kwargs.pop('working_directory', None)
         working_directory_dev_shm = kwargs.pop('working_directory_dev_shm', None)
@@ -608,7 +607,11 @@ class SearchPipe:
         package_to_taxonomy_bihash = {}
 
 
-        # HERE is the new change
+        # This code snippet counts how many hits each read has.
+        # Can be used to do read_length corrections for multihit nanopore reads.
+        # Other snippets need to be uncommented in the 
+        # UnalignedAlignedNucleotideSequence class in sequence_classes.py
+        
         # hits_per_true_name = []
         # read_to_true_name = {}
         # for readset in extracted_reads:
@@ -1019,7 +1022,7 @@ class SearchPipe:
                 collected_info.equal_best_taxonomies.append(equal_best_tax)
             collected_info.names.append(s.name)
             collected_info.unaligned_sequences.append(s.unaligned_sequence)
-            collected_info.coverage += s.coverage_increment(SHORT_READ_CORRECTION)
+            collected_info.coverage += s.coverage_increment()
             collected_info.aligned_lengths.append(s.aligned_length)
             collected_info.orf_names.append(s.orf_name)
 

--- a/singlem/pipe_sequence_extractor.py
+++ b/singlem/pipe_sequence_extractor.py
@@ -176,7 +176,7 @@ def _filter_sequences_through_hmmsearch(
     ])
     with tempfile.NamedTemporaryFile(prefix='singlem_hmmsearch_input') as input_tf:
         count, example = _generate_package_specific_fasta_input(target_sequence_ids, prefilter_result, input_tf)
-        # logging.debug("Running {} sequences through HMMSEARCH e.g. {}".format(count, example))
+        logging.debug("Running {} sequences through HMMSEARCH e.g. {}".format(count, example))
         input_tf.flush()
         if count == 0:
             return
@@ -219,7 +219,6 @@ def _generate_package_specific_fasta_input(
         if example is not None:
             example = qseqid
         output_io.write(">{}\n{}\n".format(qseqid, seq).encode())
-        # print(">{}\n{}\n".format(qseqid, seq))
 
     return count, example
 
@@ -266,10 +265,7 @@ def _extract_reads_by_diamond_for_package_and_sample(prefilter_result, spkg,
         min_orf_length,
         translation_table,
         hmmsearch_evalue))
-    
 
-    # print(spkg.graftm_package_basename())
-    # print("Found {} sequences".format(len(sequences)))
     # On very rare occasions, the same sequence can be returned twice, causing
     # hmmalign to give unexpected format output. So dedup. For instance using
     # S3.2.1 and

--- a/singlem/sequence_classes.py
+++ b/singlem/sequence_classes.py
@@ -78,7 +78,7 @@ class UnalignedAlignedNucleotideSequence:
         # original calculation
         return float(
             len(self.unaligned_sequence) /
-           (len(self.unaligned_sequence) - (self.aligned_length + 1))
+           (len(self.unaligned_sequence) - self.aligned_length + 1)
             )
     
         # ## with mild correction for multiple hits

--- a/singlem/sequence_classes.py
+++ b/singlem/sequence_classes.py
@@ -70,13 +70,39 @@ class UnalignedAlignedNucleotideSequence:
         self.unaligned_sequence = unaligned_sequence
         self.aligned_length = aligned_length
 
-    def coverage_increment(self):
+    def coverage_increment(self, short_read_correction=None):
         '''Given the alignment came from a read of length
         original_nucleotide_sequence_length, how much coverage does the
-        observation of this aligned sequence indicate?'''
-        return float(len(self.unaligned_sequence))/\
-            (len(self.unaligned_sequence)-self.aligned_length+1)
+        observation of this aligned sequence indicate?'''   
+        # original calculation
+        # return float(
+        #     len(self.unaligned_sequence) /
+        #    (len(self.unaligned_sequence) - (self.aligned_length + 1))
+        #     )
+    
+        # ## with mild correction for multiple hits
+        # return float(
+        #     len(self.unaligned_sequence) /
+        #    (len(self.unaligned_sequence) - ((self.aligned_length + 1) * self.num_hits_on_read))
+        #     )
+    
+        # ## with strong correction for long_reads
+        # if len(self.unaligned_sequence) > 300 and self.num_hits_on_read == 1:
+        #     unaligned_length = 300
+        # else:
+        #     unaligned_length = len(self.unaligned_sequence)
 
+        # print(f'Short Read Corr (seq classes): {self.short_read_correction}')
+
+        if short_read_correction:
+            unaligned_length = min(len(self.unaligned_sequence), short_read_correction)
+        else:
+            unaligned_length = len(self.unaligned_sequence)
+
+        return float(
+            (unaligned_length) /
+            (unaligned_length - self.aligned_length + 1)
+            )
 
 class SeqReader:
     # Stolen from https://github.com/lh3/readfq/blob/master/readfq.py

--- a/singlem/sequence_classes.py
+++ b/singlem/sequence_classes.py
@@ -69,16 +69,17 @@ class UnalignedAlignedNucleotideSequence:
         self.aligned_sequence = aligned_sequence
         self.unaligned_sequence = unaligned_sequence
         self.aligned_length = aligned_length
+        # self.num_hits_on_read = 1
 
-    def coverage_increment(self, short_read_correction=None):
+    def coverage_increment(self):
         '''Given the alignment came from a read of length
         original_nucleotide_sequence_length, how much coverage does the
         observation of this aligned sequence indicate?'''   
         # original calculation
-        # return float(
-        #     len(self.unaligned_sequence) /
-        #    (len(self.unaligned_sequence) - (self.aligned_length + 1))
-        #     )
+        return float(
+            len(self.unaligned_sequence) /
+           (len(self.unaligned_sequence) - (self.aligned_length + 1))
+            )
     
         # ## with mild correction for multiple hits
         # return float(
@@ -86,23 +87,6 @@ class UnalignedAlignedNucleotideSequence:
         #    (len(self.unaligned_sequence) - ((self.aligned_length + 1) * self.num_hits_on_read))
         #     )
     
-        # ## with strong correction for long_reads
-        # if len(self.unaligned_sequence) > 300 and self.num_hits_on_read == 1:
-        #     unaligned_length = 300
-        # else:
-        #     unaligned_length = len(self.unaligned_sequence)
-
-        # print(f'Short Read Corr (seq classes): {self.short_read_correction}')
-
-        if short_read_correction:
-            unaligned_length = min(len(self.unaligned_sequence), short_read_correction)
-        else:
-            unaligned_length = len(self.unaligned_sequence)
-
-        return float(
-            (unaligned_length) /
-            (unaligned_length - self.aligned_length + 1)
-            )
 
 class SeqReader:
     # Stolen from https://github.com/lh3/readfq/blob/master/readfq.py


### PR DESCRIPTION
# Working nanopore build.

### Important changes:

**DIAMOND prefilter**
1. Uses --range-culling + related args for DIAMOND.
2. These results are now streamed to help memory.
3. Sequences are indexed using gene names as well as read names.

**Pipe**
1. Refactored _remove_single_sequence_duplicates() to work with new indexing and improve readability.

**Pipe Sequence Extractor**
1. Now chunks the read_set for the hmmalign step by number of base pairs instead of number of reads.
2. Writes outputs of this step to memory to fix memory issues created by long reads.
3. Added PID info to debug statements to help when debugging multiprocessing.

### Other Changes:

1. Reformatted the coverage calculation (was testing changes, but has been left unchanged).
2. Added a __main__.py file, allowing SingleM to be run as a python module (was needed to do some benchmarking).

Left in some commented-out snippets which may be desirable in the future.
Specifically code to:

1. Count the number of hits per read + changes to the UnalignedAlignedNucleotideSequence class to use this value to correct the coverage calculation.
2. Reassign all the OTUs from a single read to the modal taxonomy of that read.

These did not make much difference to the output when applied, but were not tested extensively.
Could easily be applied without affecting short read results if deemed necessary/desirable.