### PR TITLE
Fix typo in installation docs

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -96,7 +96,7 @@ lyrebird -h
 
 After this, you'll also need to procure the reference data (the "metapackage"). See [singlem data](/tools/data).
 
-This prcedure also installs lyrebird, but the reference metapackage is different. See [lyrebird data](/tools/lyrebird_data) for more information.
+This procedure also installs lyrebird, but the reference metapackage is different. See [lyrebird data](/tools/lyrebird_data) for more information.
 
 # Example data
 

--- a/docs/Installation.md.in
+++ b/docs/Installation.md.in
@@ -96,7 +96,7 @@ lyrebird -h
 
 After this, you'll also need to procure the reference data (the "metapackage"). See [singlem data](/tools/data).
 
-This prcedure also installs lyrebird, but the reference metapackage is different. See [lyrebird data](/tools/lyrebird_data) for more information.
+This procedure also installs lyrebird, but the reference metapackage is different. See [lyrebird data](/tools/lyrebird_data) for more information.
 
 # Example data
 


### PR DESCRIPTION
## Summary
- fix a misspelling in `Installation.md`
- same fix in template `Installation.md.in`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'extern')*

------
https://chatgpt.com/codex/tasks/task_e_6875c31ae2c0832ab41bf43c86632b4e