### PR TITLE
Move setup script to admin and add AGENTS instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# AGENTS instructions
+
+Before running any commands or tests:
+1. `source admin/setup.sh` (loads Pixi dev environment and environment variables)
+2. Continue with your usual commands.

--- a/admin/setup.sh
+++ b/admin/setup.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Activate the pixi dev environment for this repository.
+
+set -e
+
+# Resolve repository root directory
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# pixi uses PIXI_PROJECT_ROOT for activation scripts.
+export PIXI_PROJECT_ROOT="$REPO_ROOT"
+
+ENV_PATH="$REPO_ROOT/.pixi/envs/dev"
+BIN_PATH="$ENV_PATH/bin"
+
+if [ -d "$BIN_PATH" ]; then
+    export PATH="$BIN_PATH:$PATH"
+    export CONDA_PREFIX="$ENV_PATH"
+else
+    echo "Pixi dev environment not found. Run 'pixi install' to create it." >&2
+    return 1 2>/dev/null || exit 1
+fi
+
+# Run additional activation script to set environment variables
+# shellcheck source=/dev/null
+. "$REPO_ROOT/admin/set_env_vars.sh"


### PR DESCRIPTION
## Summary
- Move setup script into `admin/` and adjust path resolution for repository root
- Add `AGENTS.md` instructing contributors to source the setup script before running commands or tests

## Testing
- `source admin/setup.sh && orfm -h | head -n 20`
- `source admin/setup.sh && pytest test/test_orf_length_checker.py -k small --maxfail=1`


------
https://chatgpt.com/codex/tasks/task_e_689d28728258832a8220d07640762fd2