### PR TITLE
Add flexible genome input options for pipe command

### DIFF
--- a/singlem/lyrebird.py
+++ b/singlem/lyrebird.py
@@ -22,7 +22,7 @@ sys.path = [os.path.join(os.path.dirname(os.path.realpath(__file__)),'..')] + sy
 
 import singlem
 import singlem.pipe as pipe
-from singlem.main import add_common_pipe_arguments, add_less_common_pipe_arguments, validate_pipe_args, add_condense_arguments, generate_streaming_otu_table_from_args, get_min_orf_length, get_min_taxon_coverage
+from singlem.main import add_common_pipe_arguments, add_less_common_pipe_arguments, validate_pipe_args, add_condense_arguments, generate_streaming_otu_table_from_args, get_min_orf_length, get_min_taxon_coverage, parse_genome_fasta_files
 from singlem.pipe import SearchPipe
 from singlem.condense import Condenser
 from singlem.metapackage import LYREBIRD_DATA_ENVIRONMENT_VARIABLE, CUSTOM_TAXONOMY_DATABASE_NAME
@@ -86,6 +86,7 @@ def main():
     add_condense_arguments(condense_parser)
 
     args = bird_argparser.parse_the_args()
+    parse_genome_fasta_files(args)
 
     if args.debug:
         loglevel = logging.DEBUG

--- a/test/test_pipe.py
+++ b/test/test_pipe.py
@@ -24,6 +24,7 @@
 import unittest
 import os.path
 import tempfile
+import shutil
 import extern
 import sys
 import json
@@ -1001,6 +1002,41 @@ CGGGATGTAGGCAGTGACCTCCACGCCTGAGGAGAGCCGGACGCGTGCGACCTTGCGCAACGCCGAGTTCGGCTTCTTCG
         self.assertEqualOtuTable(
             list([line.split("\t") for line in expected]),
             extern.run(cmd))
+
+    def test_genome_directory_input(self):
+        expected = [
+            "\t".join(self.headers),
+            'S1.13.ribosomal_protein_S15P_S13e\tuap2\tAAGGATTTGAGTGCAAAAAGAGGACTCGATTTTACAGAGGCAAAGATAAGAAAACTTGGA\t1\t1.00\tRoot; d__Archaea; p__Halobacterota; c__Methanomicrobia; o__Methanomicrobiales; f__Methanocullaceae; g__Methanoculleus',
+            ''
+        ]
+        with tempfile.TemporaryDirectory() as d:
+            shutil.copy(os.path.join(path_to_data, 'uap2.fna'), os.path.join(d, 'uap2.fa'))
+            cmd = '{} pipe --genome-fasta-directory {} --genome-fasta-extension fa --singlem-packages {}/S1.13.chainsaw.gpkg.spkg --otu-table /dev/stdout --assignment-method diamond'.format(
+                path_to_script,
+                d,
+                path_to_data,
+            )
+            self.assertEqualOtuTable(
+                list([line.split("\t") for line in expected]),
+                extern.run(cmd))
+
+    def test_genome_fasta_list_input(self):
+        expected = [
+            "\t".join(self.headers),
+            'S1.13.ribosomal_protein_S15P_S13e\tuap2\tAAGGATTTGAGTGCAAAAAGAGGACTCGATTTTACAGAGGCAAAGATAAGAAAACTTGGA\t1\t1.00\tRoot; d__Archaea; p__Halobacterota; c__Methanomicrobia; o__Methanomicrobiales; f__Methanocullaceae; g__Methanoculleus',
+            ''
+        ]
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.lst') as lst:
+            lst.write(os.path.join(path_to_data, 'uap2.fna'))
+            lst.flush()
+            cmd = '{} pipe --genome-fasta-list {} --singlem-packages {}/S1.13.chainsaw.gpkg.spkg --otu-table /dev/stdout --assignment-method diamond'.format(
+                path_to_script,
+                lst.name,
+                path_to_data,
+            )
+            self.assertEqualOtuTable(
+                list([line.split("\t") for line in expected]),
+                extern.run(cmd))
 
     def test_prefilter_piped_in_input(self):
         with tempfile.NamedTemporaryFile(suffix='.mkfifo.fna') as fifo:


### PR DESCRIPTION
## Summary
- Allow providing genome input via files, directories, or lists for `pipe`
- Normalize genome FASTA paths with `parse_genome_fasta_files` shared by `singlem` and `lyrebird`
- Test directory and list genome inputs

## Testing
- `pytest test/test_pipe.py::Tests::test_genome test/test_pipe.py::Tests::test_genome_directory_input test/test_pipe.py::Tests::test_genome_fasta_list_input -q`


------
https://chatgpt.com/codex/tasks/task_e_689d5b4c8074832ab8b213ba7214ccfb