### PR TITLE
Fail when --krona used with taxonomic profile input

### DIFF
--- a/docs/tools/summarise.md
+++ b/docs/tools/summarise.md
@@ -284,8 +284,7 @@ ExpressBetaDiversity -s otu_table.ebd -c Bray-Curtis
 **\--krona** *KRONA*
 
   Name of krona file to generate. Note that this generates a krona
-    file from the OTU table, not the taxonomic profile. To create a krona
-    diagram from taxonomic profiles, use --output-taxonomic-profile-krona
+    file from the OTU table, not the taxonomic profile
 
 **\--wide-format-otu-table** *WIDE_FORMAT_OTU_TABLE*
 

--- a/docs/tools/summarise.md
+++ b/docs/tools/summarise.md
@@ -284,7 +284,8 @@ ExpressBetaDiversity -s otu_table.ebd -c Bray-Curtis
 **\--krona** *KRONA*
 
   Name of krona file to generate. Note that this generates a krona
-    file from the OTU table, not the taxonomic profile
+    file from the OTU table, not the taxonomic profile. To create a krona
+    diagram from taxonomic profiles, use --output-taxonomic-profile-krona
 
 **\--wide-format-otu-table** *WIDE_FORMAT_OTU_TABLE*
 

--- a/singlem/main.py
+++ b/singlem/main.py
@@ -886,6 +886,8 @@ def main():
                 raise Exception("--collapse-paired-with-unpaired-archive-otu-table currently only works with archive tables")
             elif not len(args.input_archive_otu_tables) == 2:
                 raise Exception("--collapse-paired-with-unpaired-archive-otu-table requires exactly two archive tables")
+        if args.krona and args.input_taxonomic_profiles:
+            raise Exception("--krona generates a krona file from an OTU table. Use --output-taxonomic-profile-krona when providing taxonomic profiles")
         if args.output_taxonomic_profile_krona and not args.input_taxonomic_profiles:
             raise Exception("--output-taxonomic-profile-krona requires --input-taxonomic-profiles to be defined")
         if args.output_archive_otu_table and not args.collapse_to_sample_name:

--- a/test/test_summariser.py
+++ b/test/test_summariser.py
@@ -154,6 +154,11 @@ S1.5.ribosomal_protein_L11_rplK\tsmall\tCCTGCAGGTAAAGCGAATCCAGCACCACCAGTTGGTCCAG
                                  table_collection=table_collection)
             self.assertTrue(os.path.exists(os.path.join(tmp,'KronaOK.html')))
 
+    def test_krona_with_taxonomic_profile_input(self):
+        with self.assertRaises(Exception) as cm:
+            extern.run(f'singlem summarise --input-taxonomic-profile {path_to_data}/summarise/profile1.tsv --krona /dev/null')
+        self.assertIn('--output-taxonomic-profile-krona', str(cm.exception))
+
     def test_wide_format(self):
         e = [['gene','sample','sequence','num_hits','coverage','taxonomy'],
             ['4.11.ribosomal_protein_L10','minimal','TTACGTTCACAATTACGTGAAGCTGGTGTTGAGTATAAAGTATACAAAAACACTATGGTA','2','4.88','Root; d__Bacteria; p__Firmicutes; c__Bacilli; o__Bacillales; f__Staphylococcaceae; g__Staphylococcus'],


### PR DESCRIPTION
## Summary
- error if `singlem summarise` receives `--krona` with `--input-taxonomic-profile(s)`
- document that `--krona` only works with OTU tables and suggest `--output-taxonomic-profile-krona`
- test that the CLI rejects the invalid combination

## Testing
- `pytest test/test_summariser.py::Tests::test_krona test/test_summariser.py::Tests::test_krona_with_taxonomic_profile_input -q`


------
https://chatgpt.com/codex/tasks/task_e_68a036b5976c832a81c6fa061bb8169c