### PR TITLE
Make GTDB-Tk optional

### DIFF
--- a/admin/build_docs.py
+++ b/admin/build_docs.py
@@ -75,6 +75,7 @@ if __name__ == '__main__':
                     'appraise': 'INPUT OTU TABLE OPTIONS',
                     'seqs': 'OPTIONS',
                     'metapackage': 'OPTIONS',
+                    'supplement': 'OPTIONS',
                 }
                 logging.info("For ROFF for command {}, removing everything before '{}'".format(
                     subcommand, splitters[subcommand]))

--- a/admin/environment.yml
+++ b/admin/environment.yml
@@ -13,7 +13,6 @@ dependencies:
 - fasttree=2.1.11
 - galah=0.4.2
 - graftm=0.15.1
-- gtdbtk=2.4.1
 - hmmer=3.2.1
 - jinja2=3.1.6
 - krona=2.8.1

--- a/admin/requirements.txt
+++ b/admin/requirements.txt
@@ -3,7 +3,6 @@ biopython==1.85
 extern==0.4.1
 fastalite
 graftm==0.15.1
-gtdbtk==2.4.1
 Jinja2==3.1.6
 pandas==2.2.3
 pip==25.0.1

--- a/docs/preludes/supplement_prelude.md
+++ b/docs/preludes/supplement_prelude.md
@@ -1,0 +1,16 @@
+The SingleM `supplement` subcommand adds genomes to a SingleM metapackage.
+
+**TLDR**: Supplement a metapackage with new genomes like so:
+```
+singlem supplement --new-genome-fasta-files <genome1.fna> <genome2.fna> \
+    --output-metapackage <supplemented.smpkg>
+```
+
+## GTDB-Tk
+In order to add genomes to a metapackage, their taxonomy is required. SingleM `supplement` can generate this taxonomy for new genomes using GTDB-Tk. However, GTDB-Tk is not installed by default, and so it must be installed separately.
+
+For instance, if you are using conda to manage dependencies, use:
+```
+conda install gtdbtk
+```
+Note that the version of GTDB-Tk installed must match the GTDB release of the metapackage. The [GTDB-Tk documentation](https://ecogenomics.github.io/GTDBTk/installing/index.html) provides guidance on installation and compatibility.

--- a/docs/tools/supplement.md
+++ b/docs/tools/supplement.md
@@ -3,11 +3,16 @@ title: SingleM supplement
 ---
 # singlem supplement
 
+**TLDR**: Supplement a metapackage with new genomes like so:
+```
+singlem supplement --new-genome-fasta-files <genome1.fna> <genome2.fna> \
+    --output-metapackage <supplemented.smpkg>
+```
+GTDB-Tk may be needed to assign taxonomy to the new genomes. If required, install it separately (e.g. `conda install gtdbtk`) and ensure its version matches the GTDB release of the metapackage.
+
 # DESCRIPTION
 
 Create a new metapackage from a vanilla one plus new genomes
-
-Note that [GTDB-Tk](https://github.com/Ecogenomics/GTDBTk) is required but not installed by default. Install it separately, for example with `conda install gtdbtk`.
 
 # OPTIONS
 

--- a/docs/tools/supplement.md
+++ b/docs/tools/supplement.md
@@ -7,6 +7,8 @@ title: SingleM supplement
 
 Create a new metapackage from a vanilla one plus new genomes
 
+Note that [GTDB-Tk](https://github.com/Ecogenomics/GTDBTk) is required but not installed by default. Install it separately, for example with `conda install gtdbtk`.
+
 # OPTIONS
 
 **\--new-genome-fasta-files** *NEW_GENOME_FASTA_FILES* [*NEW_GENOME_FASTA_FILES* \...]

--- a/pixi.lock
+++ b/pixi.lock
@@ -66,7 +66,6 @@ environments:
       - conda: https://conda.anaconda.org/bioconda/noarch/graftm-0.15.1-pyhdfd78af_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/greenlet-3.2.0-py312h2ec8cdc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gsl-2.7-he838d99_0.tar.bz2
-      - conda: https://conda.anaconda.org/bioconda/noarch/gtdbtk-2.4.1-pyhdfd78af_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/h5py-3.13.0-nompi_py312hedeef09_100.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.3-nompi_hdf9ad27_105.conda
@@ -3200,7 +3199,6 @@ packages:
   - extern==0.4.1
   - fastalite
   - graftm==0.15.1
-  - gtdbtk==2.4.1
   - jinja2==3.1.6
   - pandas==2.2.3
   - pip==25.0.1

--- a/pixi.lock
+++ b/pixi.lock
@@ -36,7 +36,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2025.1.31-hbcca054_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/capnproto-1.0.2-h2b92303_1.conda
       - conda: https://conda.anaconda.org/bioconda/linux-64/cd-hit-4.8.1-h43eeafb_11.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2025.1.31-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.17.1-py312h06ac9bb_0.conda
@@ -142,7 +141,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.9.4-hcb278e6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mafft-7.526-h4bc722e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.2-py312h178313f_1.conda
-      - conda: https://conda.anaconda.org/bioconda/linux-64/mash-2.3-hc74b729_7.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.10.1-py312hd3ec401_0.conda
       - conda: https://conda.anaconda.org/bioconda/linux-64/mfqe-0.5.0-h7b50bb2_5.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mpfr-4.2.1-h90cbb55_3.conda
@@ -170,7 +168,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-16.1.0-py312h9cebb41_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-core-16.1.0-py312h0983c49_2_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pydantic-1.10.21-py312h30e4e5e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygtrie-2.5.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.2.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/bioconda/noarch/pyranges-0.1.4-pyhdfd78af_0.tar.bz2
@@ -190,7 +187,6 @@ environments:
       - conda: https://conda.anaconda.org/bioconda/noarch/seqmagick-0.8.6-pyhdfd78af_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-78.1.0-pyhff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/bioconda/linux-64/skani-0.2.2-ha6fb395_2.tar.bz2
       - conda: https://conda.anaconda.org/bioconda/linux-64/smafa-0.8.0-hc1c3326_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.2.1-h8bd8927_1.conda
       - conda: https://conda.anaconda.org/bioconda/linux-64/sorted_nearest-0.0.39-py312h0fa9677_5.tar.bz2

--- a/pixi.toml
+++ b/pixi.toml
@@ -46,7 +46,6 @@ pyarrow = "*"
 galah = ">=0.4.0"
 sqlparse = "*"  # Required indirectly (e.g. taxtastic)
 zenodo_backpack = ">=0.3.0"
-gtdbtk = "==2.4.1" # Must match the version of GTDB release used to make the default metapackage.
 # Optional (commented out)
 # python-annoy = "*"
 # nmslib = "*"
@@ -61,6 +60,7 @@ ipython = "*"
 toml = "*"
 python-build = "*"
 setuptools-scm = "*"
+gtdbtk = "==2.4.1" # Must match the version of GTDB release used to make the default metapackage.
 
 [environments]
 dev = ["dev"]

--- a/singlem/supplement.py
+++ b/singlem/supplement.py
@@ -127,6 +127,8 @@ def generate_taxonomy_for_new_genomes(**kwargs):
                 # run gtdbtk to temporary output directory
                 gtdbtk_output = os.path.join(working_directory, 'gtdbtk_output')
                 logging.info("Running GTDBtk to generate taxonomy for new genomes ..")
+                if not shutil.which("gtdbtk"):
+                    raise Exception("gtdbtk is not installed by default; install it (e.g. 'conda install gtdbtk').")
                 # logging.warning("mash_db used is specific to QUT's CMR cluster, will fix this in future")
                 cmd = f'gtdbtk classify_wf --cpus {threads} --batchfile {batchfile.name} --out_dir {gtdbtk_output} --mash_db {working_directory}/gtdbtk_mash.msh'
                 if pplacer_threads:


### PR DESCRIPTION
## Summary
- move GTDB-Tk from the main Pixi environment to dev only
- handle missing GTDB-Tk in `singlem supplement`
- document optional GTDB-Tk requirement for supplement

## Testing
- `pytest test`
- `pixi lock` *(fails: tunnel error to conda channel)*
- `pixi run test` *(fails: tunnel error to conda channel)*

------
https://chatgpt.com/codex/tasks/task_e_68a418f55fc8832a8436507f873d5de2