### PR TITLE
Rename microbial_fraction to prokaryotic_fraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* `microbial_fraction` subcommand renamed to `prokaryotic_fraction` (old name retained as synonym)
+
 ## v0.19.0
 Major new function - profiling of Caudoviricetes (aka "Caudovirales") phage communities (Lyrebird), thanks to @rzhao-2.
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Documentation can be found at https://wwood.github.io/singlem/
 <!-- NOTE: Citations should manually be kept in sync between the repo README and the docs README -->
 ### Profiling microbial communities with SingleM / Sandpiper
 Ben J. Woodcroft, Samuel T. N. Aroney, Rossen Zhao, Mitchell Cunningham, Joshua A. M. Mitchell, Rizky Nurdiansyah, Linda Blackall & Gene W. Tyson. *Comprehensive taxonomic identification of microbial species in metagenomic data using SingleM and Sandpiper.* Nat Biotechnol (2025). [https://doi.org/10.1038/s41587-025-02738-1](https://doi.org/10.1038/s41587-025-02738-1).
-### SingleM microbial_fraction
+### SingleM prokaryotic_fraction
 Raphael Eisenhofer, Antton Alberdi, Ben J. Woodcroft, 2024. *Large-scale estimation of bacterial and archaeal DNA prevalence in metagenomes reveals biome-specific patterns.* bioRxiv, pp.2024-05; [https://doi.org/10.1101/2024.05.16.594470](https://doi.org/10.1101/2024.05.16.594470).
 ### SingleM-powered coassembly with Bin Chicken
 Samuel T. N. Aroney, Rhys J. Newell, Gene W. Tyson and Ben J. Woodcroft, 2024. *Bin Chicken: targeted metagenomic coassembly for the efficient recovery of novel genomes.* bioRxiv, pp.2024-11. [https://doi.org/10.1101/2024.11.24.625082](https://doi.org/10.1101/2024.11.24.625082).

--- a/admin/build_docs.py
+++ b/admin/build_docs.py
@@ -54,7 +54,7 @@ if __name__ == '__main__':
     logging.info("Done updating [RELEASE_TAG] in Installation.md to {}".format(version))
 
     subdir_and_commands = [
-        ['tools', ['data','pipe','appraise','summarise','renew','supplement','microbial_fraction']],
+        ['tools', ['data','pipe','appraise','summarise','renew','supplement','prokaryotic_fraction']],
         ['advanced', ['makedb','query','condense','seqs','create','metapackage']]
     ]
 
@@ -68,7 +68,7 @@ if __name__ == '__main__':
                 # Remove everything before the options section
                 splitters = {
                     'pipe': 'COMMON OPTIONS',
-                    'microbial_fraction': 'OPTIONS',
+                    'prokaryotic_fraction': 'OPTIONS',
                     'data': 'OPTIONS',
                     'summarise': 'TAXONOMIC PROFILE INPUT',
                     'makedb': 'REQUIRED ARGUMENTS',

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,7 +25,7 @@ There are several tools (subcommands) which can be used after [installation](/In
 * [single summarise](/tools/summarise) - Mechanical transformations of `singlem pipe` results.
 * [singlem renew](/tools/renew) - Given previously generated results, re-run the pipeline with a new reference sequence/taxonomy database.
 * [singlem supplement](/tools/supplement) - Add new genomes to a reference metapackage.
-* [singlem microbial_fraction](/tools/microbial_fraction) - How much of a metagenome is prokaryotic?
+* [singlem prokaryotic_fraction](/tools/prokaryotic_fraction) - How much of a metagenome is prokaryotic? (also available as `microbial_fraction`)
 * [singlem appraise](/tools/appraise) - How much of a metagenome do the genomes or assembly represent?
 
 And more specialised / expert modes:
@@ -45,7 +45,7 @@ The source code is available at [https://github.com/wwood/singlem](https://githu
 <!-- NOTE: Citations should manually be kept in sync between the repo README and the docs README -->
 ### Profiling microbial communities with SingleM / Sandpiper
 Ben J. Woodcroft, Samuel T. N. Aroney, Rossen Zhao, Mitchell Cunningham, Joshua A. M. Mitchell, Rizky Nurdiansyah, Linda Blackall & Gene W. Tyson. *Comprehensive taxonomic identification of microbial species in metagenomic data using SingleM and Sandpiper.* Nat Biotechnol (2025). [https://doi.org/10.1038/s41587-025-02738-1](https://doi.org/10.1038/s41587-025-02738-1).
-### SingleM microbial_fraction
+### SingleM prokaryotic_fraction
 Raphael Eisenhofer, Antton Alberdi, Ben J. Woodcroft, 2024. *Large-scale estimation of bacterial and archaeal DNA prevalence in metagenomes reveals biome-specific patterns.* bioRxiv, pp.2024-05; [https://doi.org/10.1101/2024.05.16.594470](https://doi.org/10.1101/2024.05.16.594470).
 ### SingleM-powered coassembly with Bin Chicken
 Samuel T. N. Aroney, Rhys J. Newell, Gene W. Tyson and Ben J. Woodcroft, 2024. *Bin Chicken: targeted metagenomic coassembly for the efficient recovery of novel genomes.* bioRxiv, pp.2024-11. [https://doi.org/10.1101/2024.11.24.625082](https://doi.org/10.1101/2024.11.24.625082).

--- a/docs/preludes/prokaryotic_fraction_prelude.md
+++ b/docs/preludes/prokaryotic_fraction_prelude.md
@@ -1,6 +1,6 @@
-The SingleM `microbial_fraction` ('SMF') subcommand estimates the fraction of reads in a metagenome that are microbial, compared to everything else e.g. eukaryote- or phage-derived. Here we define 'microbial' as either bacterial or archaeal, including their plasmids. It can help prioritise samples for deeper sequencing, forecast how much sequencing is required for a given set of samples, and identify problematic steps in genome-resolved metagenomic pipelines, for instance.
+The SingleM `prokaryotic_fraction` subcommand (also available as `microbial_fraction`) estimates the fraction of reads in a metagenome that are microbial, compared to everything else e.g. eukaryote- or phage-derived. Here we define 'microbial' as either bacterial or archaeal, including their plasmids. It can help prioritise samples for deeper sequencing, forecast how much sequencing is required for a given set of samples, and identify problematic steps in genome-resolved metagenomic pipelines, for instance.
 
-SingleM `microbial_fraction` also estimates the average genome size (AGS) of microbial cells in the sample.
+SingleM `prokaryotic_fraction` also estimates the average genome size (AGS) of microbial cells in the sample.
 
 The main conceptual advantage of this method over other tools is that it does not require reference sequences of the non-microbial genomes that may be present (e.g. those of an animal host). Instead, it uses a SingleM taxonomic profile of the metagenome to "add up" the components of the community which are microbial. The remaining components are non-microbial e.g. host, diet, or phage. 
 
@@ -8,15 +8,15 @@ Roughly, the number of microbial bases is estimated by summing the genome sizes 
 
 ## Usage
 
-To run `microbial_fraction`, first run `pipe` on your metagenome.
+To run `prokaryotic_fraction`, first run `pipe` on your metagenome.
 
 ```bash
 $ singlem pipe --forward SRR9841429_1.fastq.gz --reverse SRR9841429_2.fastq.gz --threads 32 -p SRR9841429.profile
 ```
-Then run `microbial_fraction` on the profile.
+Then run `prokaryotic_fraction` on the profile.
 
 ```bash
-singlem microbial_fraction --forward SRR9841429_1.fastq.gz --reverse SRR9841429_2.fastq.gz -p SRR9841429.profile >SRR9841429.smf.tsv
+singlem prokaryotic_fraction --forward SRR9841429_1.fastq.gz --reverse SRR9841429_2.fastq.gz -p SRR9841429.profile >SRR9841429.smf.tsv
 ```
 
 The output you get is a tab-separated values file containing (with some columns omitted):
@@ -62,6 +62,6 @@ Note that the `read_fraction` and `relative_abundance` columns are percentages, 
 
 The method is least reliable in simple communities consisting of a small number of species that are missing from the reference database. The main challenge in these cases is that the genome sizes of novel species are hard to estimate accurately. Multiplying a coverage from the taxonomic profile against an uncertain genome length equals an uncertain number of bases assigned as microbial.
 
-To detect such situations SingleM `microbial_fraction` emits a warning when a sample's microbial_fraction estimate could under- or overestimate the read fraction. Specifically, the warning is emitted when the 3 highest abundance lineages not classified to the species level would change the estimated read fraction of the sample by >2% if their genome size is halved or doubled. Microbial fractions are also capped at 100% since values greater than this are impossible, but the original value can be recovered from the output if you calculate `bacterial_archaeal_bases / metagenome_size`.
+To detect such situations SingleM `prokaryotic_fraction` emits a warning when a sample's prokaryotic_fraction estimate could under- or overestimate the read fraction. Specifically, the warning is emitted when the 3 highest abundance lineages not classified to the species level would change the estimated read fraction of the sample by >2% if their genome size is halved or doubled. Prokaryotic fractions are also capped at 100% since values greater than this are impossible, but the original value can be recovered from the output if you calculate `bacterial_archaeal_bases / metagenome_size`.
 
-One current limitation of the approach relates to multi-copy plasmids. In `microbial_fraction`, the genome size of each microbial species is estimated as the sum of the chromosome and plasmid sizes, since these are the sequences available for each genome. However, in a metagenome, a species' plasmid may occur in multiple copies per cell (e.g. if the plasmid is 'high copy number'). SingleM `microbial_fraction` does not account for plasmid copy number, leading to an underestimation of the microbial fraction when plasmids are multi-copy. However, we consider this to be a minor issue, since plasmids are typically small compared to chromosomes. The average genome size estimate is unaffected by this limitation since by definition each plasmid counts only once regardless of its copy number.
+One current limitation of the approach relates to multi-copy plasmids. In `prokaryotic_fraction`, the genome size of each microbial species is estimated as the sum of the chromosome and plasmid sizes, since these are the sequences available for each genome. However, in a metagenome, a species' plasmid may occur in multiple copies per cell (e.g. if the plasmid is 'high copy number'). SingleM `prokaryotic_fraction` does not account for plasmid copy number, leading to an underestimation of the prokaryotic fraction when plasmids are multi-copy. However, we consider this to be a minor issue, since plasmids are typically small compared to chromosomes. The average genome size estimate is unaffected by this limitation since by definition each plasmid counts only once regardless of its copy number.

--- a/docs/tools/prokaryotic_fraction.md
+++ b/docs/tools/prokaryotic_fraction.md
@@ -1,10 +1,10 @@
 ---
-title: SingleM microbial_fraction
+title: SingleM prokaryotic_fraction
 ---
-# singlem microbial_fraction
-The SingleM `microbial_fraction` ('SMF') subcommand estimates the fraction of reads in a metagenome that are microbial, compared to everything else e.g. eukaryote- or phage-derived. Here we define 'microbial' as either bacterial or archaeal, including their plasmids. It can help prioritise samples for deeper sequencing, forecast how much sequencing is required for a given set of samples, and identify problematic steps in genome-resolved metagenomic pipelines, for instance.
+# singlem prokaryotic_fraction
+The SingleM `prokaryotic_fraction` subcommand (also available as `microbial_fraction`) estimates the fraction of reads in a metagenome that are microbial, compared to everything else e.g. eukaryote- or phage-derived. Here we define 'microbial' as either bacterial or archaeal, including their plasmids. It can help prioritise samples for deeper sequencing, forecast how much sequencing is required for a given set of samples, and identify problematic steps in genome-resolved metagenomic pipelines, for instance.
 
-SingleM `microbial_fraction` also estimates the average genome size (AGS) of microbial cells in the sample.
+SingleM `prokaryotic_fraction` also estimates the average genome size (AGS) of microbial cells in the sample.
 
 The main conceptual advantage of this method over other tools is that it does not require reference sequences of the non-microbial genomes that may be present (e.g. those of an animal host). Instead, it uses a SingleM taxonomic profile of the metagenome to "add up" the components of the community which are microbial. The remaining components are non-microbial e.g. host, diet, or phage. 
 
@@ -12,15 +12,15 @@ Roughly, the number of microbial bases is estimated by summing the genome sizes 
 
 ## Usage
 
-To run `microbial_fraction`, first run `pipe` on your metagenome.
+To run `prokaryotic_fraction`, first run `pipe` on your metagenome.
 
 ```bash
 $ singlem pipe --forward SRR9841429_1.fastq.gz --reverse SRR9841429_2.fastq.gz --threads 32 -p SRR9841429.profile
 ```
-Then run `microbial_fraction` on the profile.
+Then run `prokaryotic_fraction` on the profile.
 
 ```bash
-singlem microbial_fraction --forward SRR9841429_1.fastq.gz --reverse SRR9841429_2.fastq.gz -p SRR9841429.profile >SRR9841429.smf.tsv
+singlem prokaryotic_fraction --forward SRR9841429_1.fastq.gz --reverse SRR9841429_2.fastq.gz -p SRR9841429.profile >SRR9841429.smf.tsv
 ```
 
 The output you get is a tab-separated values file containing (with some columns omitted):
@@ -66,9 +66,9 @@ Note that the `read_fraction` and `relative_abundance` columns are percentages, 
 
 The method is least reliable in simple communities consisting of a small number of species that are missing from the reference database. The main challenge in these cases is that the genome sizes of novel species are hard to estimate accurately. Multiplying a coverage from the taxonomic profile against an uncertain genome length equals an uncertain number of bases assigned as microbial.
 
-To detect such situations SingleM `microbial_fraction` emits a warning when a sample's microbial_fraction estimate could under- or overestimate the read fraction. Specifically, the warning is emitted when the 3 highest abundance lineages not classified to the species level would change the estimated read fraction of the sample by >2% if their genome size is halved or doubled. Microbial fractions are also capped at 100% since values greater than this are impossible, but the original value can be recovered from the output if you calculate `bacterial_archaeal_bases / metagenome_size`.
+To detect such situations SingleM `prokaryotic_fraction` emits a warning when a sample's prokaryotic_fraction estimate could under- or overestimate the read fraction. Specifically, the warning is emitted when the 3 highest abundance lineages not classified to the species level would change the estimated read fraction of the sample by >2% if their genome size is halved or doubled. Prokaryotic fractions are also capped at 100% since values greater than this are impossible, but the original value can be recovered from the output if you calculate `bacterial_archaeal_bases / metagenome_size`.
 
-One current limitation of the approach relates to multi-copy plasmids. In `microbial_fraction`, the genome size of each microbial species is estimated as the sum of the chromosome and plasmid sizes, since these are the sequences available for each genome. However, in a metagenome, a species' plasmid may occur in multiple copies per cell (e.g. if the plasmid is 'high copy number'). SingleM `microbial_fraction` does not account for plasmid copy number, leading to an underestimation of the microbial fraction when plasmids are multi-copy. However, we consider this to be a minor issue, since plasmids are typically small compared to chromosomes. The average genome size estimate is unaffected by this limitation since by definition each plasmid counts only once regardless of its copy number.
+One current limitation of the approach relates to multi-copy plasmids. In `prokaryotic_fraction`, the genome size of each microbial species is estimated as the sum of the chromosome and plasmid sizes, since these are the sequences available for each genome. However, in a metagenome, a species' plasmid may occur in multiple copies per cell (e.g. if the plasmid is 'high copy number'). SingleM `prokaryotic_fraction` does not account for plasmid copy number, leading to an underestimation of the prokaryotic fraction when plasmids are multi-copy. However, we consider this to be a minor issue, since plasmids are typically small compared to chromosomes. The average genome size estimate is unaffected by this limitation since by definition each plasmid counts only once regardless of its copy number.
 # OPTIONS
 
 # INPUT

--- a/doctave.yml
+++ b/doctave.yml
@@ -19,7 +19,7 @@ navigation:
     - path: docs/tools/summarise.md
     - path: docs/tools/renew.md
     - path: docs/tools/supplement.md
-    - path: docs/tools/microbial_fraction.md
+    - path: docs/tools/prokaryotic_fraction.md
     - path: docs/tools/appraise.md
     - path: docs/tools/lyrebird_data.md
     - path: docs/tools/lyrebird_pipe.md

--- a/extras/update_metapackage/README.md
+++ b/extras/update_metapackage/README.md
@@ -111,5 +111,5 @@ comb %>%
         legend.title = element_text(size = 14),
         plot.title = element_text(size = 16, hjust = 0.5)
     )
-ggsave("old_vs_new_microbial_fraction.png", width = 8, height = 6, dpi = 300)
+ggsave("old_vs_new_prokaryotic_fraction.png", width = 8, height = 6, dpi = 300)
 ```

--- a/extras/update_metapackage/Snakefile
+++ b/extras/update_metapackage/Snakefile
@@ -506,7 +506,7 @@ rule sra_fractions_assigned_to_each_level:
         "--input-taxonomic-profile {input.profile} "
         "--output-taxonomic-level-coverage {output.breakdown} "
 
-rule sra_microbial_fraction:
+rule sra_prokaryotic_fraction:
     input:
         profile = output_dir + "/sra/{sra}_{version}.otu_table.condensed.tsv",
         sra_1 = lambda wildcards: config["sra_seqs_1"][wildcards.sra],
@@ -524,7 +524,7 @@ rule sra_microbial_fraction:
     log:
         logs_dir + "/sra/{sra}_{version}_smf.log"
     shell:
-        "{singlem_bin} microbial_fraction "
+        "{singlem_bin} prokaryotic_fraction "
         "--metapackage {params.metapackge} "
         "--forward {input.sra_1} "
         "--reverse {input.sra_2} "

--- a/singlem/read_fraction.py
+++ b/singlem/read_fraction.py
@@ -140,7 +140,7 @@ class ReadFractionEstimator:
                     average_genome_size_denominator += node.coverage
 
                     if '__' not in taxonomy or node.calculate_level() > 7:
-                        raise Exception("It appears that a condensed profile with a non-standard taxonomy was used. This is not supported for microbial_fraction, since microbial_fraction relies on knowing whether the taxon has been assigned to the species level or not.")
+                        raise Exception("It appears that a condensed profile with a non-standard taxonomy was used. This is not supported for prokaryotic_fraction (microbial_fraction), since prokaryotic_fraction relies on knowing whether the taxon has been assigned to the species level or not.")
                     if 's__' not in taxonomy:
                         if node.coverage > min_unknown_taxon_priority:
                             if len(highest_unknown_taxon_names) < num_unknown_taxa_accounted_for:

--- a/test/test_prokaryotic_fraction.py
+++ b/test/test_prokaryotic_fraction.py
@@ -37,7 +37,7 @@ class Tests(unittest.TestCase):
     maxDiff = None
 
     def test_marine0(self):
-        cmd = "{} microbial_fraction -p {}/read_fraction/marine0.profile  --input-metagenome-sizes {}/read_fraction/marine0.num_bases --taxon-genome-lengths-file {}/read_fraction/gtdb_mean_genome_sizes.tsv".format(
+        cmd = "{} prokaryotic_fraction -p {}/read_fraction/marine0.profile  --input-metagenome-sizes {}/read_fraction/marine0.num_bases --taxon-genome-lengths-file {}/read_fraction/gtdb_mean_genome_sizes.tsv".format(
             path_to_script,
             path_to_data,
             path_to_data,
@@ -46,7 +46,7 @@ class Tests(unittest.TestCase):
         self.assertEqual('\t'.join(self.output_headers) + '\n' + '\t'.join(str.split('marine0.1       16593586562      17858646300.0   92.92   3718692') + [''] + str.split('0.08    0.22    0.43    0.55    2.08    6.06    90.58')) + '\n', obs)
 
     def test_smafa_count_unpaired(self):
-        cmd = "{} microbial_fraction -p {}/read_fraction/marine0.profile  --forward {}/read_fraction/marine0.1.fa --taxon-genome-lengths-file {}/read_fraction/gtdb_mean_genome_sizes.tsv".format(
+        cmd = "{} prokaryotic_fraction -p {}/read_fraction/marine0.profile  --forward {}/read_fraction/marine0.1.fa --taxon-genome-lengths-file {}/read_fraction/gtdb_mean_genome_sizes.tsv".format(
             path_to_script,
             path_to_data,
             path_to_data,
@@ -55,7 +55,7 @@ class Tests(unittest.TestCase):
         self.assertEqual('\t'.join(self.output_headers)+'\n' + '\t'.join(str.split('marine0.1       16593586562      3       100.00  3718692')+['WARNING: The most abundant taxons not assigned to the species level account for a large fraction of the total estimated read fraction. This may mean that the read_fraction estimate is inaccurate.'] + str.split('0.08    0.22    0.43    0.55    2.08    6.06    90.58'))+'\n', obs)
 
     def test_smafa_count_paired(self):
-        cmd = "{} microbial_fraction -p {}/read_fraction/marine0.profile  --forward {}/read_fraction/marine0.1.fa --reverse {}/read_fraction/marine0.2.fa --taxon-genome-lengths-file {}/read_fraction/gtdb_mean_genome_sizes.tsv".format(
+        cmd = "{} prokaryotic_fraction -p {}/read_fraction/marine0.profile  --forward {}/read_fraction/marine0.1.fa --reverse {}/read_fraction/marine0.2.fa --taxon-genome-lengths-file {}/read_fraction/gtdb_mean_genome_sizes.tsv".format(
             path_to_script,
             path_to_data,
             path_to_data,
@@ -65,7 +65,7 @@ class Tests(unittest.TestCase):
         self.assertEqual('\t'.join(self.output_headers)+'\n' + '\t'.join(str.split('marine0.1       16593586562      6       100.00    3718692')+['WARNING: The most abundant taxons not assigned to the species level account for a large fraction of the total estimated read fraction. This may mean that the read_fraction estimate is inaccurate.'] + str.split('0.08    0.22    0.43    0.55    2.08    6.06    90.58'))+'\n', obs)
 
     def test_output_per_taxon_read_fractions(self):
-        cmd = "{} microbial_fraction -p <(head -5 {}/read_fraction/marine0.profile) --input-metagenome-sizes {}/read_fraction/marine0.num_bases --taxon-genome-lengths-file {}/read_fraction/gtdb_mean_genome_sizes.tsv --output-tsv /dev/null --output-per-taxon-read-fractions /dev/stdout".format(
+        cmd = "{} prokaryotic_fraction -p <(head -5 {}/read_fraction/marine0.profile) --input-metagenome-sizes {}/read_fraction/marine0.num_bases --taxon-genome-lengths-file {}/read_fraction/gtdb_mean_genome_sizes.tsv --output-tsv /dev/null --output-per-taxon-read-fractions /dev/stdout".format(
             path_to_script,
             path_to_data,
             path_to_data,
@@ -81,7 +81,7 @@ marine0.1	p__Proteobacteria	7151244.856821437
     def test_average_genome_size(self):
         '''Here the ave genome size has been checked by hand'''
 
-        cmd = "{} microbial_fraction -p <(head -5 {}/read_fraction/marine0.profile)  --input-metagenome-sizes {}/read_fraction/marine0.num_bases --taxon-genome-lengths-file {}/read_fraction/gtdb_mean_genome_sizes.tsv".format(
+        cmd = "{} prokaryotic_fraction -p <(head -5 {}/read_fraction/marine0.profile)  --input-metagenome-sizes {}/read_fraction/marine0.num_bases --taxon-genome-lengths-file {}/read_fraction/gtdb_mean_genome_sizes.tsv".format(
             path_to_script,
             path_to_data,
             path_to_data,
@@ -91,6 +91,15 @@ marine0.1	p__Proteobacteria	7151244.856821437
 
 
 
+
+    def test_alias_microbial_fraction(self):
+        cmd = "{} microbial_fraction -p {}/read_fraction/marine0.profile  --input-metagenome-sizes {}/read_fraction/marine0.num_bases --taxon-genome-lengths-file {}/read_fraction/gtdb_mean_genome_sizes.tsv".format(
+            path_to_script,
+            path_to_data,
+            path_to_data,
+            path_to_data)
+        obs = extern.run(cmd)
+        self.assertEqual('\t'.join(self.output_headers) + '\n' + '\t'.join(str.split('marine0.1       16593586562      17858646300.0   92.92   3718692') + [''] + str.split('0.08    0.22    0.43    0.55    2.08    6.06    90.58')) + '\n', obs)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- rename `microbial_fraction` subcommand to `prokaryotic_fraction`
- retain `microbial_fraction` as a deprecated alias
- update docs, tests, and build scripts for new name

## Testing
- `pixi run test`

------
https://chatgpt.com/codex/tasks/task_e_68b93ebc219c832aa5e94faf7cb43081