### PR TITLE
Add split at calculating trimmed mean in Condenser.py and thus works …

### DIFF
--- a/singlem/condense.py
+++ b/singlem/condense.py
@@ -215,14 +215,15 @@ class Condenser:
                     for seq_id in seq_id_list:
                         taxon_name = sequence_id_to_taxon[seq_id]
                         if not taxon_name[-2].startswith('g__'):
-                            if not taxon_name[0] == 'd__Eukaryota':
-                                # add one check to ensure the target taxon to be d__Eukaryota for all metapackages.
-                                if all("Eukaryota" in domain for domain in target_domain):
-                                    # then the bacterial/archaeal sequences are off-target this time. 
-                                    logging.debug("Ignoring off-target prokaryotic taxon {}".format(taxon_name))
-                                    continue
-                                else:
-                                    raise Exception("Expected genus level taxon, but found {}, from ID {}".format(taxon_name, seq_id))
+                            if not taxon_name[0] in target_domain:
+                                # # add one check to ensure the target taxon to be d__Eukaryota for all metapackages.
+                                # if all("Eukaryota" in domain for domain in target_domain):
+                                #     # then the bacterial/archaeal sequences are off-target this time. 
+                                #     logging.debug("Ignoring off-target prokaryotic taxon {}".format(taxon_name))
+                                #     continue
+                                # else:
+                                #     raise Exception("Expected genus level taxon, but found {}, from ID {}".format(taxon_name, seq_id))
+                                continue
                             else:
                                 # This can happen when taxonomy is overall
                                 # Archaea so not previously filtered out, but


### PR DESCRIPTION
Hi Ben and singleM team,

You may remember my posts in the issue #255 that when I tried with my plastid markers' metapackage, I found that the program failed at Condenser.py (trying to output the krona plot) while trying to apply the genus-wise expectation maximization and calculating the trimmed mean. After a try, I found that: 
 - 1. My meta package contains Cyanobacteria sequences, but in the domain-to-gene dictionary storing each domain's gene list (i.e.: {"Bacteria":[], "Archaea": [], "eukaryote":[gene1, gene2, gene3]}), the bacteria gets an empty list, which contributes to that particular zero division error in trimmed_mean function. Now, in my forked version, I rewired the function to just skip the error, because in my context I would not include Bacteria in my krona plot. I then run the singleM using the default meta package that you and your team curated, it seems that nothing is going wrong. 

So finally, I made this pull request, to see if you could merge.

Cheers
Andy

Melbourne Integrative Genomics, University of Melbourne