### PR TITLE
Refine ORF nucleotide handling after diamond prefilter

### DIFF
--- a/singlem/diamond_spkg_searcher.py
+++ b/singlem/diamond_spkg_searcher.py
@@ -75,9 +75,9 @@ class DiamondSpkgSearcher:
 
             # DIAMOND command
             # now with range culling, etc
-            cmd = [ 
+            cmd = [
                 "diamond", "blastx",
-                "--outfmt", "6", "qseqid", "full_qseq", "sseqid", "qstart",
+                "--outfmt", "6", "qseqid", "full_qseq", "sseqid", "qstart", "qend", "qframe",
                 "--max-target-seqs", "1",
                 "--evalue", "0.01",
                 "--frameshift", "15",
@@ -97,7 +97,7 @@ class DiamondSpkgSearcher:
                 with open(fasta_path, 'a') as fasta_file:
                     for line in proc.stdout:
                         try:
-                            qseqid, full_qseq, sseqid, qstart = line.strip().split('\t')
+                            qseqid, full_qseq, sseqid, qstart, qend, qframe = line.strip().split('\t')
                         except ValueError:
                             raise Exception(f"Unexpected line format for DIAMOND output line '{line.strip()}'")
                     
@@ -111,10 +111,16 @@ class DiamondSpkgSearcher:
                             continue
 
                         # store the best hit for each query sequence to feed into the next steps
-                        best_hits[qseqid] = sseqid
+                        best_hits[qseqid] = {
+                            'sseqid': sseqid,
+                            'qstart': int(qstart),
+                            'qend': int(qend),
+                            'qframe': int(qframe),
+                            'length': len(full_qseq),
+                        }
 
                         # write the query sequence to a file
-                        fasta_file.write(f'>{qseqid}\n{full_qseq}\n')    
+                        fasta_file.write(f'>{qseqid}\n{full_qseq}\n')
 
                 # check for DIAMOND errors
                 stderr_output = proc.stderr.read()

--- a/singlem/metagenome_otu_finder.py
+++ b/singlem/metagenome_otu_finder.py
@@ -69,23 +69,49 @@ class MetagenomeOtuFinder:
                         # On rare occasions, the dummy sequence is aligned to
                         # the HMM in the right place, ignore it.
                         continue
-                    
-                    nuc = nucleotide_sequences[name]
-                    aligned_nucleotides = s.orfm_nucleotides(nuc)
+                    if s.name in nucleotide_sequences:
+                        nuc_entry = nucleotide_sequences[s.name]
+                    elif name in nucleotide_sequences:
+                        nuc_entry = nucleotide_sequences[name]
+                    else:
+                        continue
+
+                    if isinstance(nuc_entry, tuple):
+                        if len(nuc_entry) == 3:
+                            nuc, original_length, full_nuc = nuc_entry
+                        else:
+                            nuc, original_length = nuc_entry
+                            full_nuc = nuc
+                    else:
+                        nuc = nuc_entry
+                        original_length = len(nuc_entry)
+                        full_nuc = nuc_entry
+                    nucleotide_source = full_nuc if full_nuc is not None else nuc
+                    aligned_nucleotides = s.orfm_nucleotides(nucleotide_source)
                 else:
                     name = s.name
                     if name == 'dummy':
                         # On rare occasions, the dummy sequence is aligned to
                         # the HMM in the right place, ignore it.
                         continue
-                    nuc = nucleotide_sequences[name]
+                    nuc_entry = nucleotide_sequences[name]
+                    if isinstance(nuc_entry, tuple):
+                        if len(nuc_entry) == 3:
+                            nuc, original_length, full_nuc = nuc_entry
+                        else:
+                            nuc, original_length = nuc_entry
+                            full_nuc = nuc
+                    else:
+                        nuc = nuc_entry
+                        original_length = len(nuc_entry)
+                        full_nuc = nuc_entry
                     aligned_nucleotides = nuc.replace('-','')
                 align, aligned_length = self._nucleotide_alignment(
                     s, aligned_nucleotides, chosen_positions, is_protein_alignment,
                     include_inserts=include_inserts)
 
                 windowed_sequences.append(
-                    UnalignedAlignedNucleotideSequence(name, s.name, align, nuc, aligned_length))
+                    UnalignedAlignedNucleotideSequence(name, s.name, align, full_nuc, aligned_length, original_length))
         return windowed_sequences
 
     def _find_lower_case_columns(self, protein_alignment):


### PR DESCRIPTION
## Summary
- adjust nucleotide handling when converting aligned protein sequences to nucleotide windows to prefer full sequences when available
- preserve untrimmed nucleotide context when preparing ORFs for hmmsearch while still tracking read lengths
- keep ORF read tuples compatible with downstream alignment and coverage calculations

## Testing
- pixi run -e dev pytest test/test_pipe.py -k genome_input_dereplication -q (fails: genome dereplication expectation still mismatched)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935fe6b5ab8832aa4a2b20e7d71b5d1)