### PR TITLE
Generate zipped OTU table fixtures in renew tests

### DIFF
--- a/singlem/lyrebird.py
+++ b/singlem/lyrebird.py
@@ -74,7 +74,9 @@ def main():
     renew_description = 'Reannotate an OTU table with an updated taxonomy'
     renew_parser = bird_argparser.new_subparser('renew', renew_description, parser_group='Tools')
     renew_input_args = renew_parser.add_argument_group('input')
-    renew_input_args.add_argument('--input-archive-otu-table', help="Renew this table", required=True)
+    renew_input_tables = renew_input_args.add_mutually_exclusive_group(required=True)
+    renew_input_tables.add_argument('--input-archive-otu-table', help="Renew this table")
+    renew_input_tables.add_argument('--input-zipped-gzip-archive-otu-table', help="Archive OTU table stored as a gzip file inside a zip file. Provide as ZIP_PATH:MEMBER_PATH")
     renew_input_args.add_argument('--ignore-missing-singlem-packages', help="Ignore OTUs which have been assigned to packages not in the metapackage being used for renewal [default: croak]", action='store_true')
     renew_common = renew_parser.add_argument_group("Common arguments in shared with 'pipe'")
     add_common_pipe_arguments(renew_common)
@@ -152,6 +154,7 @@ def main():
         validate_pipe_args(args, subparser='renew')
         Renew().renew(
             input_archive_otu_table=args.input_archive_otu_table,
+            input_zipped_gzip_archive_otu_table=args.input_zipped_gzip_archive_otu_table,
             ignore_missing_singlem_packages=args.ignore_missing_singlem_packages,
             otu_table = args.otu_table,
             output_archive_otu_table = args.archive_otu_table,

--- a/singlem/main.py
+++ b/singlem/main.py
@@ -615,7 +615,9 @@ def main():
     renew_description = 'Reannotate an OTU table with an updated taxonomy'
     renew_parser = bird_argparser.new_subparser('renew', renew_description, parser_group='Tools')
     renew_input_args = renew_parser.add_argument_group('input')
-    renew_input_args.add_argument('--input-archive-otu-table', help="Renew this table", required=True)
+    renew_input_tables = renew_input_args.add_mutually_exclusive_group(required=True)
+    renew_input_tables.add_argument('--input-archive-otu-table', help="Renew this table")
+    renew_input_tables.add_argument('--input-zipped-gzip-archive-otu-table', help="Archive OTU table stored as a gzip file inside a zip file. Provide as ZIP_PATH:MEMBER_PATH")
     renew_input_args.add_argument('--ignore-missing-singlem-packages', help="Ignore OTUs which have been assigned to packages not in the metapackage being used for renewal [default: croak]", action='store_true')
     renew_common = renew_parser.add_argument_group("Common arguments in shared with 'pipe'")
     add_common_pipe_arguments(renew_common)
@@ -827,6 +829,7 @@ def main():
         validate_pipe_args(args, subparser='renew')
         Renew().renew(
             input_archive_otu_table=args.input_archive_otu_table,
+            input_zipped_gzip_archive_otu_table=args.input_zipped_gzip_archive_otu_table,
             ignore_missing_singlem_packages=args.ignore_missing_singlem_packages,
             otu_table = args.otu_table,
             output_archive_otu_table = args.archive_otu_table,


### PR DESCRIPTION
## Summary
- generate the zipped gzip OTU table fixture on the fly inside test_renew instead of storing a binary archive
- restore the original renew CLI tests and add dedicated coverage for --input-zipped-gzip-archive-otu-table for both executables
- remove the checked-in renew_archive_tables.zip test asset

## Testing
- pixi run -e dev pytest test/test_renew.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949b8ee52b4832a9ddb347aecdd09ad)