### PR TITLE
summarise: Add --output-cami-iii-gtdb-profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+* `summarise`: Add `--output-cami-iii-gtdb-profile`, which converts a taxonomic profile into the [CAMI III GTDB taxonomic profiling format](https://cami-challenge.org/file-formats/#taxonomic-profiling), for benchmarking against other profilers with e.g. OPAL. Requires `--input-taxonomic-profiles`.
 * `pipe`: Frameshift repair, which uses the frameshifts DIAMOND reports during the prefilter to restore the reading frame of each read before it is aligned to the HMM, so reads carrying single base indels still yield a window, is now on by default. Substantially improves window recovery on Nanopore data, where indels rather than substitutions are the dominant error. Where a repaired deletion leaves a base of unknown identity, it is taken from the most abundant window within `--max-frameshift-repair-divergence` mismatches, and only for windows where repair actually inserted that base, not a pre-existing ambiguous base in the raw read. Disable with `--no-repair-frameshifts`. 
 
 ## v0.21.3

--- a/docs/preludes/summarise_prelude.md
+++ b/docs/preludes/summarise_prelude.md
@@ -76,6 +76,26 @@ marine0.1  0.8       0.8            11.13               phylum  Root; d__Bacteri
 marine0.1  2.17      2.17           30.18               phylum  Root; d__Bacteria; p__Proteobacteria
 ```
 
+## Conversion to CAMI III GTDB profile format
+Taxonomic profiles can be converted to the [CAMI III GTDB taxonomic profiling format](https://cami-challenge.org/file-formats/#taxonomic-profiling), for comparison against other profilers using e.g. [OPAL](https://github.com/CAMI-challenge/OPAL):
+```
+singlem summarise --input-taxonomic-profile doco_example.profile \
+    --output-cami-iii-gtdb-profile doco_example.cami.profile
+```
+The generated `doco_example.cami.profile` contains
+```
+@SampleID:marine0.1
+@Version:0.9.2
+@Ranks:domain|phylum|class|order|family|genus|species
+@@TAXID	RANK	TAXPATH	TAXPATHSN	PERCENTAGE
+d__Archaea	domain	d__Archaea	d__Archaea	58.41446
+d__Bacteria	domain	d__Bacteria	d__Bacteria	41.58554
+p__Thermoproteota	phylum	d__Archaea|p__Thermoproteota	d__Archaea|p__Thermoproteota	7.7886
+p__Desulfobacterota	phylum	d__Bacteria|p__Desulfobacterota	d__Bacteria|p__Desulfobacterota	11.12656
+p__Proteobacteria	phylum	d__Bacteria|p__Proteobacteria	d__Bacteria|p__Proteobacteria	30.18081
+```
+Percentages are relative abundances of the [filled coverage](/Glossary#coverage-unfilled-coverage-and-filled-coverage) of each taxon. GTDB taxon names are used in place of NCBI taxonomy IDs, since this format is GTDB-based. Each sample in the input is written as its own header block, which is how a multi-sample profile file is delimited. Since GTDB covers prokaryotes only, profiles containing eukaryotic or viral domains (e.g. from Lyrebird) are rejected.
+
 # Summarising OTU tables
 The following describes how summarise can be used to transform [OTU tables](/Glossary#otu-table), rather than [taxonomomic profiles](/Glossary#taxonomic-profile). 
 

--- a/singlem/condense.py
+++ b/singlem/condense.py
@@ -1059,5 +1059,55 @@ class CondensedCommunityProfileKronaWriter:
             f.close()
 
 
+class CondensedCommunityProfileCamiIiiGtdbWriter:
+    '''Writes taxonomic profiles in the CAMI III GTDB taxonomic profiling
+    format, described at https://cami-challenge.org/file-formats/#taxonomic-profiling'''
+
+    VERSION = '0.9.2'
+    RANKS = ['domain', 'phylum', 'class', 'order', 'family', 'genus', 'species']
+    # GTDB covers prokaryotes only, so eukaryotic and viral domains (e.g. from
+    # lyrebird, or a metapackage with eukaryotic markers) cannot be represented.
+    ACCEPTED_DOMAINS = set(['d__Bacteria', 'd__Archaea'])
+
+    @staticmethod
+    def write_profile(condensed_profiles, output_io):
+        for profile in condensed_profiles:
+            unacceptable_domains = [
+                d for d in profile.tree.children.keys()
+                if d not in CondensedCommunityProfileCamiIiiGtdbWriter.ACCEPTED_DOMAINS]
+            if len(unacceptable_domains) > 0:
+                raise Exception(
+                    "The CAMI III GTDB taxonomic profiling format assumes GTDB ranks and taxonomy, which "
+                    "covers Bacteria and Archaea only, so the domain(s) {} found in sample {} cannot be "
+                    "converted to it.".format(', '.join(sorted(unacceptable_domains)), profile.sample))
+
+            print("@SampleID:{}".format(profile.sample), file=output_io)
+            print("@Version:{}".format(CondensedCommunityProfileCamiIiiGtdbWriter.VERSION), file=output_io)
+            print("@Ranks:{}".format('|'.join(CondensedCommunityProfileCamiIiiGtdbWriter.RANKS)), file=output_io)
+            print("@@TAXID\tRANK\tTAXPATH\tTAXPATHSN\tPERCENTAGE", file=output_io)
+
+            total_coverage = sum(
+                node.get_full_coverage() for node in profile.tree.children.values())
+            if total_coverage == 0:
+                continue
+
+            for node in profile.breadth_first_iter():
+                level = node.calculate_level() - 1 # 0-based rank index, Root is -1
+                if level < 0 or level >= len(CondensedCommunityProfileCamiIiiGtdbWriter.RANKS):
+                    continue
+                coverage = node.get_full_coverage()
+                if coverage == 0:
+                    continue
+                taxpathsn = '|'.join(node.get_taxonomy()[1:]) # drop 'Root'
+                percentage = coverage / total_coverage * 100
+                print("\t".join([
+                    node.word,
+                    CondensedCommunityProfileCamiIiiGtdbWriter.RANKS[level],
+                    taxpathsn,
+                    taxpathsn,
+                    str(round(percentage, 5)),
+                ]), file=output_io)
+
+
 
 

--- a/singlem/main.py
+++ b/singlem/main.py
@@ -558,6 +558,7 @@ def main():
     # Note: num decimal places default should align with the default in summariser.py
     summarise_taxonomic_profile_output_args.add_argument('--num-decimal-places', metavar='INT', type=int, help="Number of decimal places to report in the coverage column of the --output-taxonomic-profile-with-extras [default: 2].")
     summarise_taxonomic_profile_output_args.add_argument('--output-taxonomic-level-coverage', metavar='FILE', help="Output summary of how much coverage has been assigned to each taxonomic level in a taxonomic profile to a TSV file.")
+    summarise_taxonomic_profile_output_args.add_argument('--output-cami-iii-gtdb-profile', metavar='FILE', help="Output taxonomic profile to this file in the CAMI III GTDB taxonomic profiling format (https://cami-challenge.org/file-formats/#taxonomic-profiling).")
     
     summarise_otu_table_input_args = summarise_parser.add_argument_group('OTU table input')
     summarise_otu_table_input_args.add_argument('--input-otu-tables', '--input-otu-table', nargs='+', help="Summarise these tables")
@@ -907,6 +908,7 @@ def main():
         if args.output_taxonomic_level_coverage: num_output_types += 1
         if args.output_filled_taxonomic_profile: num_output_types += 1
         if args.output_taxonomic_profile_with_extras: num_output_types += 1
+        if args.output_cami_iii_gtdb_profile: num_output_types += 1
         if num_output_types != 1:
             raise Exception("Exactly 1 output type must be specified, sorry, %i were provided" % num_output_types)
         if not args.input_otu_tables and \
@@ -947,6 +949,8 @@ def main():
             raise Exception("--output-taxonomic-profile-with-extras requires --input-taxonomic-profiles to be defined")
         if args.num_decimal_places and not args.output_taxonomic_profile_with_extras:
             raise Exception("--num-decimal-places currently requires --output-taxonomic-profile-with-extras to be defined")
+        if args.output_cami_iii_gtdb_profile and not args.input_taxonomic_profiles:
+            raise Exception("--output-cami-iii-gtdb-profile requires --input-taxonomic-profiles to be defined")
 
         if args.stream_inputs or args.unaligned_sequences_dump_file:
             from singlem.otu_table_collection import StreamingOtuTableCollection
@@ -1139,6 +1143,11 @@ def main():
                         input_taxonomic_profile_files = args.input_taxonomic_profiles,
                         output_taxonomic_profile_extras_io = f,
                         num_decimal_places = args.num_decimal_places)
+            elif args.output_cami_iii_gtdb_profile:
+                with open(args.output_cami_iii_gtdb_profile, 'w') as f:
+                    Summariser.write_cami_iii_gtdb_profile(
+                        input_taxonomic_profile_files = args.input_taxonomic_profiles,
+                        output_cami_iii_gtdb_profile_io = f)
             else:
                 raise Exception("Expected --output-taxonomic-profile-krona or --output-site-by-species-relative-abundance or --output-taxonomic-level-coverage to be defined, since --input-taxonomic-profiles was defined")
 

--- a/singlem/summariser.py
+++ b/singlem/summariser.py
@@ -12,7 +12,7 @@ from .rarefier import Rarefier
 from .ordered_set import OrderedSet
 from .archive_otu_table import ArchiveOtuTable
 from .taxonomy import QUERY_BASED_ASSIGNMENT_METHOD, DIAMOND_ASSIGNMENT_METHOD, NO_ASSIGNMENT_METHOD
-from .condense import CondensedCommunityProfile
+from .condense import CondensedCommunityProfile, CondensedCommunityProfileCamiIiiGtdbWriter
 
 class Summariser:
     @staticmethod
@@ -691,3 +691,21 @@ class Summariser:
                         num_printed += 1
 
         logging.info("Wrote {} lines of taxonomic profile with extras".format(num_printed))
+
+    @staticmethod
+    def write_cami_iii_gtdb_profile(**kwargs):
+        input_taxonomic_profile_files = kwargs.pop('input_taxonomic_profile_files')
+        output_io = kwargs.pop('output_cami_iii_gtdb_profile_io')
+        if len(kwargs) > 0:
+            raise Exception("Unexpected arguments detected: %s" % kwargs)
+
+        logging.info("Writing CAMI III GTDB taxonomic profile")
+
+        num_samples = 0
+        for profile_file in input_taxonomic_profile_files:
+            with open(profile_file) as f:
+                for profile in CondensedCommunityProfile.each_sample_wise(f):
+                    CondensedCommunityProfileCamiIiiGtdbWriter.write_profile([profile], output_io)
+                    num_samples += 1
+
+        logging.info("Wrote CAMI III GTDB taxonomic profile for {} sample(s)".format(num_samples))

--- a/test/test_summariser.py
+++ b/test/test_summariser.py
@@ -479,6 +479,49 @@ land       2.17      2.17           30.26               phylum      Root; d__Bac
 """)
         self.assertEqual(expected, stdout)
 
+    def test_output_cami_iii_gtdb_profile(self):
+        stdout = extern.run(f'singlem summarise --input-taxonomic-profile {path_to_data}/condense/small_condense_output.csv \
+            --output-cami-iii-gtdb-profile /dev/stdout')
+        expected = \
+            "@SampleID:anonymous_reads\n" \
+            "@Version:0.9.2\n" \
+            "@Ranks:domain|phylum|class|order|family|genus|species\n" \
+            "@@TAXID\tRANK\tTAXPATH\tTAXPATHSN\tPERCENTAGE\n" \
+            "d__Archaea\tdomain\td__Archaea\td__Archaea\t10.09761\n" \
+            "d__Bacteria\tdomain\td__Bacteria\td__Bacteria\t89.90239\n" \
+            "p__Proteobacteria\tphylum\td__Bacteria|p__Proteobacteria\td__Bacteria|p__Proteobacteria\t44.87827\n" \
+            "c__Gammaproteobacteria\tclass\td__Bacteria|p__Proteobacteria|c__Gammaproteobacteria\td__Bacteria|p__Proteobacteria|c__Gammaproteobacteria\t44.87827\n"
+        self.assertEqual(expected, stdout)
+
+    def test_output_cami_iii_gtdb_profile_multiple_samples(self):
+        # Each sample gets its own header block, which is how OPAL delimits
+        # samples within a single profile file.
+        stdout = extern.run(f'singlem summarise --input-taxonomic-profile {path_to_data}/condense/small_condense_output_2_samples.csv \
+            --output-cami-iii-gtdb-profile /dev/stdout')
+        self.assertEqual(
+            ['@SampleID:anonymous_reads', '@SampleID:anonymous_reads2'],
+            [line for line in stdout.split('\n') if line.startswith('@SampleID')])
+        self.assertEqual(2, stdout.count('@@TAXID\tRANK\tTAXPATH\tTAXPATHSN\tPERCENTAGE'))
+
+    def test_output_cami_iii_gtdb_profile_requires_taxonomic_profile_input(self):
+        with self.assertRaises(Exception) as cm:
+            extern.run(f'singlem summarise --input-otu-tables {path_to_data}/small.otu_table.csv \
+                --output-cami-iii-gtdb-profile /dev/stdout')
+        self.assertIn('--output-cami-iii-gtdb-profile requires --input-taxonomic-profiles', str(cm.exception))
+
+    def test_output_cami_iii_gtdb_profile_rejects_non_prokaryotic_domains(self):
+        for domain in ['d__Viruses', 'd__Eukaryota']:
+            with tempfile.NamedTemporaryFile(mode='w', suffix='.profile') as f:
+                f.write("sample\tcoverage\ttaxonomy\n")
+                f.write("sample1\t1.5\tRoot; d__Bacteria\n")
+                f.write(f"sample1\t1.5\tRoot; {domain}\n")
+                f.flush()
+                with self.assertRaises(Exception) as cm:
+                    extern.run(f'singlem summarise --input-taxonomic-profile {f.name} \
+                        --output-cami-iii-gtdb-profile /dev/null')
+                self.assertIn(domain, str(cm.exception))
+                self.assertIn('Bacteria and Archaea only', str(cm.exception))
+
     def test_taxonomic_profile_coverage_not_down_to_species(self):
         stdout = extern.run(f'singlem summarise --input-taxonomic-profile {path_to_data}/summarise/marine0.head5.profile \
             --output-taxonomic-level-coverage /dev/stdout')


### PR DESCRIPTION
## Summary
- Adds `--output-cami-iii-gtdb-profile` to `summarise`, converting a taxonomic profile into the [CAMI III GTDB taxonomic profiling format](https://cami-challenge.org/file-formats/#taxonomic-profiling) for comparison against other profilers with e.g. OPAL. Requires `--input-taxonomic-profiles`.
- Percentages are relative abundances of each taxon's filled coverage. GTDB taxon names stand in for NCBI taxonomy IDs, since the format is GTDB-based.
- Viral profiles are rejected, as the format assumes GTDB bacterial/archaeal ranks and taxonomy.

The only addition to `condense.py` is `CondensedCommunityProfileCamiIiiGtdbWriter`, which takes an open IO handle to match the other summariser writers; `Condenser.condense` is untouched. Only the hand-written `docs/preludes/summarise_prelude.md` is updated — `docs/tools/summarise.md` is generated at release.

## Test plan
- [x] `pytest test/test_summariser.py test/test_condense.py` — 46 passed, 1 skipped
- [x] `pytest test/test_condense_viral.py`, and `test/test_pipe.py -k "profile or diamond_assignment"` — pass (full `test_pipe.py` not run)
- [x] New CLI tests covering the conversion output, the missing-`--input-taxonomic-profiles` error, and viral rejection
- [x] Confirmed the option text added to the prelude matches what `summarise --full-help-roff` generates

🤖 Generated with [Claude Code](https://claude.com/claude-code)